### PR TITLE
fix: add commit message so that existing/future dependebot PRs don't have package version issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,13 @@ updates:
     directory: "/" # path where poetry.lock, pyroject.toml lives
     schedule:
       interval: "monthly"
+    commit-message:
+      # prefix all commit messages with "fix: " for commitezen to bump package version automatically
+      prefix: "fix" # github automatically adds a ":" after the prefix
   - package-ecosystem: "pip"
     directory: "/" # path where .github/ lives
     schedule:
       interval: "monthly"
+    commit-message:
+      # prefix all commit messages with "fix: " for commitezen to bump package version automatically
+      prefix: "fix" # github automatically adds a ":" after the prefix


### PR DESCRIPTION
This PR adds commit-message prefix to all dependebot PRs. The current issue is:

1. The pipeline automatically bumps the package version according to the commit message i.e. `fix`, `feat` etc.
2. Dependebot PRs don't have these prefix keywords so the pipeline will always fail.
3. There are two open dependebot PRs which cannot be merged because of the above issues.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#commit-message.