### PR TITLE
fix: change graphql endpoint to target domain name instead

### DIFF
--- a/move_ugc/settings.py
+++ b/move_ugc/settings.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     """Global settings to be used by the SDK."""
 
     ugc_endpoint_url: HttpUrl = Field(
-        default="https://7oknhjzasjd25ifi3pqdco4mxa.appsync-api.eu-west-1.amazonaws.com/graphql",
+        default="https://api.move.ai/ugc/graphql",
         description="Move UGC API endpoint URL",
         title="GraphQL endpoint URL",
     )


### PR DESCRIPTION
Change url to point to domain instead of using the appsync url