### PR TITLE
fix: IST-1196: `after` is actually a json string

### DIFF
--- a/move_ugc/schemas/commons.py
+++ b/move_ugc/schemas/commons.py
@@ -2,7 +2,7 @@
 import enum
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, Json
 from typing_extensions import Annotated
 
 from move_ugc.schemas.job import JobType
@@ -10,6 +10,7 @@ from move_ugc.schemas.take import TakeType
 from move_ugc.settings import get_settings
 
 LIST_ITEM_TYPE = List[Dict[str, Any]]
+DICT_AS_JSON_STRING_TYPE = Json[Dict[str, Any]]
 
 
 def validate_list_items_type(
@@ -67,7 +68,7 @@ class ListBase(BaseModel):
         description="Number of items to be returned.",
         alias="first",
     )
-    next_token: Optional[Dict[str, Any]] = Field(
+    next_token: Optional[DICT_AS_JSON_STRING_TYPE] = Field(
         default=None,
         description="Cursor for the next page.",
         alias="after",

--- a/tests/fixtures/conftest/commons.py
+++ b/tests/fixtures/conftest/commons.py
@@ -1,4 +1,5 @@
 """Common fixtures for the UGC Client shared across types."""
+import json
 from typing import Any, Dict
 
 import pytest
@@ -32,6 +33,6 @@ def build_list_response(fake_response, faker) -> Dict[str, Any]:
     """
     return {
         "first": faker.pyint(),
-        "after": faker.pydict(value_types=["str"]),
+        "after": json.dumps(faker.pydict(value_types=["str"])),
         "items": [fake_response],
     }


### PR DESCRIPTION
This was discovered while creating integration tests as part of IST-1196
