### PR TITLE
feat: IST-2249 - Trigger integration tests from move-services-testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,43 @@ on:
 
 
 jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    name: Integration tests
+    strategy:
+      fail-fast: false
+      matrix:
+        test-name:
+          - "create_volume_with_human"
+          - "create_multi_cam_take"
+          - "create_multi_cam_job"
+          - "list_takes"
+          - "list_jobs"
+          - "list_volumes"
+          - "create_files"
+          - "share_files"
+          - "update_file"
+          - "update_job"
+          - "update_take"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: move-ai/move-services-testing
+          ref: feature/IST-2249-ugc-python
+          ssh-key: ${{ secrets.INTEGRATION_TESTS_PRIVATE_KEY }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run test suite
+        # Must be relative path because we're using an action from local path
+        uses: ./.github/actions/ugc-python
+        with:
+          test-name: ${{ matrix.test-name }}
+          api-key: ${{ secrets.API_KEY_QA_CLIENT_DEFAULT }}
+          endpoint-url: ${{ secrets.UGC_API_ENDPOINT_URL }}
+          python-version: "3.11"
+          rev: ${{ github.sha }}
+
   publish:
     name: "Publish ${{ github.ref_name }}"
     runs-on: "ubuntu-latest"
@@ -15,6 +52,8 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
       contents: read
+    needs:
+      - integration-tests
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -34,6 +73,8 @@ jobs:
   release:
     name: "Release ${{ github.ref_name }}"
     runs-on: "ubuntu-latest"
+    needs:
+      - integration-tests
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: move-ai/move-services-testing
-          ref: feature/IST-2249-ugc-python
           ssh-key: ${{ secrets.INTEGRATION_TESTS_PRIVATE_KEY }}
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
If integration tests don't pass we shouldn't publish the docs and deploy the newer version to pypi