### PR TITLE
BREAKING CHANGE: IST-2638: Move clip window to job from sources

### DIFF
--- a/docs/api-reference/schemas/job.md
+++ b/docs/api-reference/schemas/job.md
@@ -2,4 +2,10 @@
     options:
         members: ["id", "created", "metadata", "client", "outputs", "state", "take"]
 
+::: move_ugc.schemas.job.ClipWindow
+    options:
+        members:
+            - start_time
+            - end_time
+
 ::: move_ugc.schemas.job.JobOptions

--- a/docs/api-reference/schemas/sources.md
+++ b/docs/api-reference/schemas/sources.md
@@ -13,12 +13,6 @@
         members:
             - lens
 
-::: move_ugc.schemas.sources.ClipWindow
-    options:
-        members:
-            - start_time
-            - end_time
-
 ::: move_ugc.schemas.sources.AdditionalFileType
     options:
         members:
@@ -33,7 +27,6 @@
             - file_id
             - format
             - camera_settings
-            - clip_window
 
 ::: move_ugc.schemas.sources.Source
     options:
@@ -42,4 +35,3 @@
             - file
             - format
             - camera_settings
-            - clip_window

--- a/docs/getting-started/usage/job.md
+++ b/docs/getting-started/usage/job.md
@@ -11,6 +11,22 @@ Before creating a job, please make sure that a take is created. If you've not cr
 job = ugc.jobs.create_singlecam(take_id="take-2be2463e-ffa3-419b-beb4-ea0f99c79512")
 ```
 
+## Specifying a clip window
+
+You can specify how much of your input video you wish to process. If not provided the entire
+video will be processed
+
+```python
+job = ugc.jobs.create_singlecam(
+    take_id="take-2be2463e-ffa3-419b-beb4-ea0f99c79512",
+    clip_window=ClipWindow(
+        start_time=0,
+        end_time=10,
+    ),
+)
+
+
+```
 ## Attaching some custom metadata with your job
 
 The metadata attribute in job type accepts any valid json string and can contain any custom data. This is particularly useful if any business logic needs to be implemented such as attaching a user id to a job.

--- a/docs/getting-started/usage/multicam/quickstart.md
+++ b/docs/getting-started/usage/multicam/quickstart.md
@@ -25,10 +25,6 @@ ugc.volumes.create_human_volume(
     sources=[
         SourceIn(
             source_id="source-1",
-            clip_window=ClipWindow(
-                start_time=0,
-                end_time=10,
-            ),
             file_id="file-2be2463e-ffa3-419b-beb4-ea0f99c79592",
             format=TakeSourceKey.MP4,
             camera_settings={
@@ -37,10 +33,6 @@ ugc.volumes.create_human_volume(
         ),
         SourceIn(
             source_id="source-2",
-            clip_window=ClipWindow(
-                start_time=0,
-                end_time=10,
-            ),
             file_id="file-edcf5b93-24b4-45b8-91b2-0985c4c44665",
             format=TakeSourceKey.MP4,
             camera_settings={
@@ -75,10 +67,6 @@ take = ugc.takes.create_multicam(
     sources=[
         SourceIn(
             source_id="source-1",
-            clip_window=ClipWindow(
-                start_time=0,
-                end_time=10,
-            ),
             file_id="file-2be2463e-ffa3-419b-beb4-ea0f99c79592",
             format=TakeSourceKey.MP4,
             camera_settings={
@@ -87,10 +75,6 @@ take = ugc.takes.create_multicam(
         ),
         SourceIn(
             source_id="source-2",
-            clip_window=ClipWindow(
-                start_time=0,
-                end_time=10,
-            ),
             file_id="file-edcf5b93-24b4-45b8-91b2-0985c4c44665",
             format=TakeSourceKey.MP4,
             camera_settings={
@@ -99,6 +83,10 @@ take = ugc.takes.create_multicam(
         ),
     ],
     volume_id="volume-2be2463e-ffa3-419b-beb4-ea0f99c79512",
+    clip_window=ClipWindow(
+        start_time=0,
+        end_time=10,
+    ),
 )
 ```
 

--- a/move_ugc/gql_requests/job.py
+++ b/move_ugc/gql_requests/job.py
@@ -29,7 +29,8 @@ create = UgcGql(
         $name: String,
         $options: OptionsInput,
         $outputs: [OutputType],
-        $metadata: AWSJSON
+        $metadata: AWSJSON,
+        $clip_window: ClipWindowInput
     ) {{{{
         createSingleCamJob(
             takeId: $take_id,
@@ -37,6 +38,7 @@ create = UgcGql(
             options: $options,
             outputs: $outputs,
             metadata: $metadata
+            clipWindow: $clip_window
         ) {{{{
             {job_attributes}
         }}}}
@@ -59,7 +61,8 @@ create_multicam = UgcGql(
         $options: OptionsInput,
         $outputs: [OutputType],
         $metadata: AWSJSON,
-        $rig: String
+        $rig: String,
+        $clip_window: ClipWindowInput,
     ) {{{{
         createMultiCamJob(
             takeId: $take_id,
@@ -69,6 +72,7 @@ create_multicam = UgcGql(
             outputs: $outputs,
             metadata: $metadata
             rig: $rig
+            clipWindow: $clip_window
         ) {{{{
             {job_attributes}
         }}}}

--- a/move_ugc/gql_requests/take.py
+++ b/move_ugc/gql_requests/take.py
@@ -30,10 +30,6 @@ expand_sources_multicam = f"""
         {expand_video_file}
         format
         {expand_camera_settings}
-        clipWindow {{
-            startTime
-            endTime
-        }}
     }}
 """
 

--- a/move_ugc/gql_requests/volume.py
+++ b/move_ugc/gql_requests/volume.py
@@ -26,6 +26,7 @@ create = UgcGql(
         $humanHeight: Float!,
         $metadata: AWSJSON,
         $name: String,
+        $clip_window: ClipWindowInput,
     ) {{{{
         createVolumeWithHuman(
             sources: $sources,
@@ -34,6 +35,7 @@ create = UgcGql(
             humanHeight: $humanHeight,
             metadata: $metadata,
             name: $name,
+            clipWindow: $clip_window
         ) {{{{
             {human_volume_attributes}
         }}}}

--- a/move_ugc/schemas/job.py
+++ b/move_ugc/schemas/job.py
@@ -11,6 +11,23 @@ from move_ugc.schemas.sources import AdditionalFileType
 from move_ugc.schemas.take import TakeType
 
 
+class ClipWindow(BaseModel):
+    """Clip window for cropping a source."""
+
+    start_time: float = Field(
+        description="Start time of the clip window",
+        title="Start time",
+        examples=[0],
+        serialization_alias="startTime",
+    )
+    end_time: float = Field(
+        description="End time of the clip window",
+        title="End time",
+        examples=[10.0],
+        serialization_alias="endTime",
+    )
+
+
 class JobOptions(BaseModel):
     """Options which can be used for creating a job in MoveUGC.
 

--- a/move_ugc/schemas/sources.py
+++ b/move_ugc/schemas/sources.py
@@ -55,23 +55,6 @@ class CameraSettings(BaseModel):
     )
 
 
-class ClipWindow(BaseModel):
-    """Clip window for cropping a source."""
-
-    start_time: float = Field(
-        description="Start time of the clip window",
-        title="Start time",
-        examples=[0],
-        serialization_alias="startTime",
-    )
-    end_time: float = Field(
-        description="End time of the clip window",
-        title="End time",
-        examples=[10.0],
-        serialization_alias="endTime",
-    )
-
-
 class AdditionalFileType(BaseModel):
     """Representation for Additional File type in MoveUGC."""
 
@@ -125,14 +108,6 @@ class SourceIn(BaseModel, use_enum_values=True):
         default=None,
     )
 
-    clip_window: Optional[ClipWindow] = Field(
-        description="Clip window for cropping the source",
-        title="Clip window",
-        examples=[{"startTime": 0, "endTime": 10}],
-        serialization_alias="clipWindow",
-        default=None,
-    )
-
 
 class Source(BaseModel):
     """Representation for Source type in MoveUGC."""
@@ -158,11 +133,5 @@ class Source(BaseModel):
         title="Camera settings",
         examples=[{"lens": "goprohero10-2-7k"}],
         serialization_alias="cameraSettings",
-        default=None,
-    )
-    clip_window: Optional[ClipWindow] = Field(
-        description="Clip window for the source",
-        title="Clip window",
-        examples=[{"startTime": 0, "endTime": 10}],
         default=None,
     )

--- a/move_ugc/services/job.py
+++ b/move_ugc/services/job.py
@@ -8,7 +8,7 @@ from move_ugc.gql_requests.job import retrieve as retrieve_query
 from move_ugc.gql_requests.job import update as update_query
 from move_ugc.schemas.commons import ListBase, SortDirection, get_default_page_size
 from move_ugc.schemas.constants import ALLOWED_EXPAND_ATTRS
-from move_ugc.schemas.job import JobOptions, JobType
+from move_ugc.schemas.job import ClipWindow, JobOptions, JobType
 from move_ugc.services.base import BaseService
 
 
@@ -38,6 +38,7 @@ class JobService(BaseService[JobType]):
         name: Optional[str] = "",
         metadata: Optional[Dict[str, Any]] = None,
         options: Optional[JobOptions] = None,
+        clip_window: Optional[ClipWindow] = None,
         outputs: Optional[List[str]] = None,
         expand: Optional[List[ALLOWED_EXPAND_ATTRS]] = None,
     ) -> JobType:
@@ -54,6 +55,9 @@ class JobService(BaseService[JobType]):
                 options to be used for creating the job.
                 Check all the valid allowed options in the API documentation.
                 https://move-ai.github.io/move-ugc-api/schema/#optionsinput
+            clip_window:
+                The clip window that you want to process.
+                If not provided the entire video is processed
             outputs:
                 list of output types to be created for this job.
             expand:
@@ -73,6 +77,9 @@ class JobService(BaseService[JobType]):
                 "options": options.model_dump(by_alias=True, mode="json"),
                 "outputs": [str(output).upper() for output in outputs or []],
                 "metadata": self.encode_aws_metadata(metadata),
+                "clip_window": clip_window.model_dump(by_alias=True)
+                if clip_window
+                else None,
             },
         )
 
@@ -84,6 +91,7 @@ class JobService(BaseService[JobType]):
         outputs: Optional[List[str]] = None,
         rig: Optional[str] = "",
         name: Optional[str] = "",
+        clip_window: Optional[ClipWindow] = None,
         metadata: Optional[Dict[str, Any]] = None,
         expand: Optional[List[ALLOWED_EXPAND_ATTRS]] = None,
     ) -> JobType:
@@ -104,6 +112,9 @@ class JobService(BaseService[JobType]):
                 rig to be used for creating the job.
             name:
                 name to be used for creating the job.
+            clip_window:
+                The clip window that you want to process.
+                If not provided the entire video is processed
             metadata:
                 metadata to be used for creating the job. This should be a valid json string.
             expand:
@@ -125,6 +136,9 @@ class JobService(BaseService[JobType]):
                 "outputs": [str(output).upper() for output in outputs or []],
                 "metadata": self.encode_aws_metadata(metadata),
                 "rig": rig,
+                "clip_window": clip_window.model_dump(by_alias=True)
+                if clip_window
+                else None,
             },
         )
 

--- a/move_ugc/services/volume.py
+++ b/move_ugc/services/volume.py
@@ -6,6 +6,7 @@ from move_ugc.gql_requests.volume import create as create_query
 from move_ugc.gql_requests.volume import list_query, retrieve_human_volume
 from move_ugc.schemas.commons import ListBase, SortDirection, get_default_page_size
 from move_ugc.schemas.constants import ALLOWED_EXPAND_ATTRS
+from move_ugc.schemas.job import ClipWindow
 from move_ugc.schemas.sources import SourceIn
 from move_ugc.schemas.sync_method import SyncMethodInput
 from move_ugc.schemas.volume import AreaType, HumanVolumeType
@@ -40,6 +41,7 @@ class VolumeService(BaseService[HumanVolumeType]):
         sync_method: Optional[SyncMethodInput] = None,
         metadata: Optional[Dict[str, Any]] = None,
         name: Optional[str] = None,
+        clip_window: Optional[ClipWindow] = None,
         expand: Optional[List[ALLOWED_EXPAND_ATTRS]] = None,
     ) -> HumanVolumeType:
         """Create a human volume with given sources in MoveUGC.
@@ -57,6 +59,9 @@ class VolumeService(BaseService[HumanVolumeType]):
                 metadata to be used for creating the volume. This should be a valid json string.
             name:
                 name of the volume.
+            clip_window:
+                The clip window that you want to process.
+                If not provided the entire video is processed
             expand:
                 list of fields to be expanded.
 
@@ -75,6 +80,9 @@ class VolumeService(BaseService[HumanVolumeType]):
                 ),
                 "metadata": self.encode_aws_metadata(metadata),
                 "name": name or "",
+                "clip_window": clip_window.model_dump(by_alias=True)
+                if clip_window
+                else None,
             },
         )
 

--- a/tests/fixtures/json/introspection.json
+++ b/tests/fixtures/json/introspection.json
@@ -1,4488 +1,4824 @@
 {
-   "data": {
-       "__schema": {
-           "queryType": {
-               "name": "Query"
-           },
-           "mutationType": {
-               "name": "Mutation"
-           },
-           "subscriptionType": null,
-           "types": [
-               {
-                   "kind": "OBJECT",
-                   "name": "Query",
-                   "description": "  List of available queries in UGC API.",
-                   "fields": [
-                       {
-                           "name": "client",
-                           "description": "  Returns the current client details.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Client",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "getFile",
-                           "description": "  Get file details with given file id.",
-                           "args": [
-                               {
-                                   "name": "fileId",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "ID",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "File",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "getJob",
-                           "description": "  Get job details from given job id.",
-                           "args": [
-                               {
-                                   "name": "jobId",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "ID",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Job",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "getTake",
-                           "description": "  Get a take with given id.",
-                           "args": [
-                               {
-                                   "name": "takeId",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "ID",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Take",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "getVolume",
-                           "description": "  Get a volume with the given id.",
-                           "args": [
-                               {
-                                   "name": "id",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "ID",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "UNION",
-                                   "name": "Volume",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "listCameraSettings",
-                           "description": "  Get a list of camera settings",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "CameraSettingsPage",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "listJobs",
-                           "description": "  Get a list of jobs.",
-                           "args": [
-                               {
-                                   "name": "first",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "Int",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "after",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "AWSJSON",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "sortDirection",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "ENUM",
-                                       "name": "SortDirection",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "takeId",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "String",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "JobsPage",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "listRigs",
-                           "description": "  Get a list of all available rigs.",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "RigsPage",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "listTakes",
-                           "description": "  Get a list of takes.",
-                           "args": [
-                               {
-                                   "name": "first",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "Int",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "after",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "AWSJSON",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "sortDirection",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "ENUM",
-                                       "name": "SortDirection",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "TakesPage",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "listVolumes",
-                           "description": "  Get a list of volumes.",
-                           "args": [
-                               {
-                                   "name": "first",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "Int",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "after",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "AWSJSON",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "sortDirection",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "ENUM",
-                                       "name": "SortDirection",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "VolumePage",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "Client",
-                   "description": "  Representation of a Client account.",
-                   "fields": [
-                       {
-                           "name": "created",
-                           "description": "  Datetime at which the Client was created.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "AWSDateTime",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "id",
-                           "description": "  Unique identifier for this client.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "ID",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "metadata",
-                           "description": "  Metadata for the client to store any key value pairs - json validation done by AWS",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSJSON",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "name",
-                           "description": "  Name associated to this client.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "portal",
-                           "description": "  Portal url associated to this client.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSURL",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [
-                       {
-                           "kind": "INTERFACE",
-                           "name": "Identifier",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "INTERFACE",
-                           "name": "Timestamped",
-                           "ofType": null
-                       }
-                   ],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "SCALAR",
-                   "name": "AWSDateTime",
-                   "description": "The `AWSDateTime` scalar type provided by AWS AppSync, represents a valid ***extended*** [ISO 8601 DateTime](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) string. In other words, this scalar type accepts datetime strings of the form `YYYY-MM-DDThh:mm:ss.SSSZ`.  The scalar can also accept \"negative years\" of the form `-YYYY` which correspond to years before `0000`. For example, \"**-2017-01-01T00:00Z**\" and \"**-9999-01-01T00:00Z**\" are both valid datetime strings.  The field after the two digit seconds field is a nanoseconds field. It can accept between 1 and 9 digits. So, for example, \"**1970-01-01T12:00:00.2Z**\", \"**1970-01-01T12:00:00.277Z**\" and \"**1970-01-01T12:00:00.123456789Z**\" are all valid datetime strings.  The seconds and nanoseconds fields are optional (the seconds field must be specified if the nanoseconds field is to be used).  The [time zone offset](https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators) is compulsory for this scalar. The time zone offset must either be `Z` (representing the UTC time zone) or be in the format `±hh:mm:ss`. The seconds field in the timezone offset will be considered valid even though it is not part of the ISO 8601 standard.",
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "SCALAR",
-                   "name": "ID",
-                   "description": "Built-in ID",
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "SCALAR",
-                   "name": "AWSJSON",
-                   "description": "The `AWSJSON` scalar type provided by AWS AppSync, represents a JSON string that complies with [RFC 8259](https://tools.ietf.org/html/rfc8259).  Maps like \"**{\\\\\"upvotes\\\\\": 10}**\", lists like \"**[1,2,3]**\", and scalar values like \"**\\\\\"AWSJSON example string\\\\\"**\", \"**1**\", and \"**true**\" are accepted as valid JSON and will automatically be parsed and loaded in the resolver mapping templates as Maps, Lists, or Scalar values rather than as the literal input strings.  Invalid JSON strings like \"**{a: 1}**\", \"**{'a': 1}**\" and \"**Unquoted string**\" will throw GraphQL validation errors.",
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "SCALAR",
-                   "name": "String",
-                   "description": "Built-in String",
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "SCALAR",
-                   "name": "AWSURL",
-                   "description": "The `AWSURL` scalar type provided by AWS AppSync, represents a valid URL string (Ex: <https://www.amazon.com/>). The URL may use any scheme and may also be a local URL (Ex: <http://localhost/>).  URLs without schemes like \"**amazon.com**\" or \"**www.amazon.com**\" are considered invalid. URLs which contain double slashes (two consecutive forward slashes) in their path are also considered invalid.",
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "INTERFACE",
-                   "name": "Identifier",
-                   "description": "  Implement this interface to add an identifier to your schema",
-                   "fields": [
-                       {
-                           "name": "id",
-                           "description": "  Unique identifier.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "ID",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": [
-                       {
-                           "kind": "OBJECT",
-                           "name": "Client",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "OBJECT",
-                           "name": "File",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "OBJECT",
-                           "name": "Job",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "OBJECT",
-                           "name": "Take",
-                           "ofType": null
-                       }
-                   ]
-               },
-               {
-                   "kind": "INTERFACE",
-                   "name": "Timestamped",
-                   "description": "  Implement this interface to make your schema timestampable",
-                   "fields": [
-                       {
-                           "name": "created",
-                           "description": "  The child type should define this attribute.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSDateTime",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": [
-                       {
-                           "kind": "OBJECT",
-                           "name": "Client",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "OBJECT",
-                           "name": "File",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "OBJECT",
-                           "name": "Job",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "OBJECT",
-                           "name": "Take",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "OBJECT",
-                           "name": "ShareCode",
-                           "ofType": null
-                       }
-                   ]
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "File",
-                   "description": "  Represents a File in UGC API.",
-                   "fields": [
-                       {
-                           "name": "client",
-                           "description": "  Associated client account which created this file.",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "Client",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "created",
-                           "description": "  Datetime at which the file was created.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSDateTime",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "id",
-                           "description": "  Unique identifier for a File.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "ID",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "metadata",
-                           "description": "  Metadata for the client to store any key value pairs - json validation done by AWS",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSJSON",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "name",
-                           "description": "  Name of the file.Returns null if no name present.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "presignedUrl",
-                           "description": "  Url to upload/download the file. When creating a file, this attribute will return a upload url. Otherwise, this attribute will represent a download url.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSURL",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "thumbnailUrl",
-                           "description": "  The url of the thumbnail file. Returns null if no thumbnail present",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSURL",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "type",
-                           "description": "  Type (extension) of a file. Example: mp4, mov, avi etc.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [
-                       {
-                           "kind": "INTERFACE",
-                           "name": "Identifier",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "INTERFACE",
-                           "name": "Timestamped",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "INTERFACE",
-                           "name": "InternalFileSchema",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "INTERFACE",
-                           "name": "ClientOwner",
-                           "ofType": null
-                       }
-                   ],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "INTERFACE",
-                   "name": "InternalFileSchema",
-                   "description": "  Implement this interface to add internal file service structure to your schema",
-                   "fields": [
-                       {
-                           "name": "presignedUrl",
-                           "description": "  Url to upload/download the file. When creating a file, this attribute will return a upload url. Otherwise, this attribute will represent a download url.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSURL",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "type",
-                           "description": "  Type (extension) of a file. Example: mp4, mov, avi etc.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": [
-                       {
-                           "kind": "OBJECT",
-                           "name": "File",
-                           "ofType": null
-                       }
-                   ]
-               },
-               {
-                   "kind": "INTERFACE",
-                   "name": "ClientOwner",
-                   "description": "  Implement this interface if your schema has a client owner",
-                   "fields": [
-                       {
-                           "name": "client",
-                           "description": "  Reference to the associated Client owner.",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "Client",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": [
-                       {
-                           "kind": "OBJECT",
-                           "name": "File",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "OBJECT",
-                           "name": "Job",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "OBJECT",
-                           "name": "Take",
-                           "ofType": null
-                       }
-                   ]
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "Job",
-                   "description": "  Represents an animation job for a take",
-                   "fields": [
-                       {
-                           "name": "client",
-                           "description": "  Client owner of this job",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Client",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "created",
-                           "description": "  Datetime at which the job was created",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSDateTime",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "id",
-                           "description": "  Unique identifier for the job",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "ID",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "metadata",
-                           "description": "  Metadata json field where the client can store any key value pair",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSJSON",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "name",
-                           "description": "  Name of the job.Returns null if no name present.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "outputs",
-                           "description": "  Outputs of this job",
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "AdditionalFile",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "rig",
-                           "description": "  Name of the rig to use. If not provided, the default rig will be used",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "Rig",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "state",
-                           "description": "  Current status of the job",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "take",
-                           "description": "  Reference to the original take",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "Take",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [
-                       {
-                           "kind": "INTERFACE",
-                           "name": "Identifier",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "INTERFACE",
-                           "name": "Timestamped",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "INTERFACE",
-                           "name": "ClientOwner",
-                           "ofType": null
-                       }
-                   ],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "AdditionalFile",
-                   "description": "  An additional file which may be attached to the take",
-                   "fields": [
-                       {
-                           "name": "file",
-                           "description": "  Reference to the additional file object",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "File",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "format",
-                           "description": "  Type of additional file",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "key",
-                           "description": "  Type of additional file",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "Rig",
-                   "description": "  Represents the rig details attached to a particular job.",
-                   "fields": [
-                       {
-                           "name": "name",
-                           "description": "  The name of the rig that was used to create the job.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "Take",
-                   "description": "  Representation of a take",
-                   "fields": [
-                       {
-                           "name": "additionalFiles",
-                           "description": "  Optional additional files for this take",
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "AdditionalFile",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "client",
-                           "description": "  Reference to the client owner of the take",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Client",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "created",
-                           "description": "  Datetime string at which the take was created",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "AWSDateTime",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "id",
-                           "description": "   Unique id of a take ",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "ID",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "metadata",
-                           "description": "  Metadata for the client to store any key value pairs - json validation done by AWS",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSJSON",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "name",
-                           "description": "  Name of the take. Returns null if no name present.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "sources",
-                           "description": "  Sources associated with the take.",
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Source",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "syncMethod",
-                           "description": "  The sync method for the input sources on this take. If not provided it is assumed that all source inputs are fully synced.",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "SyncMethod",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "takeType",
-                           "description": "  Type of the take (this can be either a multiple or singlecam take).",
-                           "args": [],
-                           "type": {
-                               "kind": "ENUM",
-                               "name": "TakeType",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "videoFile",
-                           "description": "  Reference to the video file included with this take",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "File",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "volume",
-                           "description": "  Volume associated with a multicam take.",
-                           "args": [],
-                           "type": {
-                               "kind": "UNION",
-                               "name": "Volume",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [
-                       {
-                           "kind": "INTERFACE",
-                           "name": "Identifier",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "INTERFACE",
-                           "name": "Timestamped",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "INTERFACE",
-                           "name": "ClientOwner",
-                           "ofType": null
-                       }
-                   ],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "Source",
-                   "description": "  The source device, file and camera settings to use for a take.",
-                   "fields": [
-                       {
-                           "name": "cameraSettings",
-                           "description": "  Settings for the camera that was used to capture this source.",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "CameraSettings",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "clipWindow",
-                           "description": "  The clip window that should be processed. If not provided the entire source will be processed.",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "ClipWindow",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "deviceLabel",
-                           "description": "  A user defined label for the device this source input was captured on.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "file",
-                           "description": "  Reference to the file object of this source.",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "File",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "format",
-                           "description": "  The file format of the source.",
-                           "args": [],
-                           "type": {
-                               "kind": "ENUM",
-                               "name": "SourceFormat",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "CameraSettings",
-                   "description": "  The camera settings for the source",
-                   "fields": [
-                       {
-                           "name": "lens",
-                           "description": "  The name of the lens that was used to create the capture inputs.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "ClipWindow",
-                   "description": "  The start and end time of the clip window that should be processed. startTime should be before endTime.",
-                   "fields": [
-                       {
-                           "name": "endTime",
-                           "description": "  The end time of the clip window to be processed.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "Float",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "startTime",
-                           "description": "  The start time of the clip window to be processed.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "Float",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "SCALAR",
-                   "name": "Float",
-                   "description": "Built-in Float",
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "ENUM",
-                   "name": "SourceFormat",
-                   "description": null,
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": [
-                       {
-                           "name": "AVI",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "MOV",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "MOVE",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "MP4",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "SyncMethod",
-                   "description": "  The type of sync method. If not provided it is assumed that all source inputs are fully synced.",
-                   "fields": [
-                       {
-                           "name": "clapWindow",
-                           "description": "  The input sources were synced via a clap.",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "ClapWindow",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "timecodeSync",
-                           "description": "  The input sources were synced via a timecode.",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "TimeCodeSync",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "ClapWindow",
-                   "description": "  The start and end time of the clap window that should be used for syncing sources. startTime should be before endTime",
-                   "fields": [
-                       {
-                           "name": "endTime",
-                           "description": "  The end time of the clap window that was used to sync the input sources.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "Float",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "startTime",
-                           "description": "  The start time of the clap window that was used to sync the input sources.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "Float",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "TimeCodeSync",
-                   "description": "  Are the source files synced via a timecode",
-                   "fields": [
-                       {
-                           "name": "useTimecode",
-                           "description": "  The source inputs are timecode synced.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "Boolean",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "SCALAR",
-                   "name": "Boolean",
-                   "description": "Built-in Boolean",
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "ENUM",
-                   "name": "TakeType",
-                   "description": null,
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": [
-                       {
-                           "name": "MULTI_CAM",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "SINGLE_CAM",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "UNION",
-                   "name": "Volume",
-                   "description": "  A volume used in a multicam take will be one of these types.",
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": [
-                       {
-                           "kind": "OBJECT",
-                           "name": "HumanVolume",
-                           "ofType": null
-                       }
-                   ]
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "HumanVolume",
-                   "description": "  Represents volumes for a multicam take\n A volume that was created using a human.",
-                   "fields": [
-                       {
-                           "name": "areaType",
-                           "description": "  Area type of the volume.",
-                           "args": [],
-                           "type": {
-                               "kind": "ENUM",
-                               "name": "AreaType",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "client",
-                           "description": "  Reference to the client owner of the volume.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Client",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "created",
-                           "description": "  Datetime at which the volume was created",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "AWSDateTime",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "humanHeight",
-                           "description": "  Height of the human present in the volume.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "Float",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "id",
-                           "description": "  Unique id of a volume. This is the volume job id.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "ID",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "metadata",
-                           "description": "  Metadata for the client to store any key value pairs - json validation done by AWS.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSJSON",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "name",
-                           "description": "  Name of the human volume. Returns null if no name present.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "outputs",
-                           "description": "  Outputs of this volume.",
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "AdditionalFile",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "sources",
-                           "description": "  Input source files required for creating HumanVolume, sources from at least two cameras are required.",
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "NON_NULL",
-                                   "name": null,
-                                   "ofType": {
-                                       "kind": "OBJECT",
-                                       "name": "Source",
-                                       "ofType": null
-                                   }
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "state",
-                           "description": "  Current status of the volume processing.",
-                           "args": [],
-                           "type": {
-                               "kind": "ENUM",
-                               "name": "JobState",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "ENUM",
-                   "name": "AreaType",
-                   "description": null,
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": [
-                       {
-                           "name": "LARGE",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "NORMAL",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "ENUM",
-                   "name": "JobState",
-                   "description": null,
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": [
-                       {
-                           "name": "FAILED",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "FINISHED",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "NOT_STARTED",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "RUNNING",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "CameraSettingsPage",
-                   "description": "  CameraSettings model connection. This connection will return a page of camera settings.",
-                   "fields": [
-                       {
-                           "name": "after",
-                           "description": "  Next page token",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSJSON",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "first",
-                           "description": "  Number of items on the single page",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "Int",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "items",
-                           "description": "  List of items on the current page",
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "CameraSettings",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [
-                       {
-                           "kind": "INTERFACE",
-                           "name": "Page",
-                           "ofType": null
-                       }
-                   ],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "SCALAR",
-                   "name": "Int",
-                   "description": "Built-in Int",
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "INTERFACE",
-                   "name": "Page",
-                   "description": "  Implement this interface for your schema page",
-                   "fields": [
-                       {
-                           "name": "after",
-                           "description": "  Next token for the items to be fetched in the remaining pages.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSJSON",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "first",
-                           "description": "  Items to fetch in a single page. Defaults to 50.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "Int",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": [
-                       {
-                           "kind": "OBJECT",
-                           "name": "CameraSettingsPage",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "OBJECT",
-                           "name": "JobsPage",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "OBJECT",
-                           "name": "RigsPage",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "OBJECT",
-                           "name": "TakesPage",
-                           "ofType": null
-                       },
-                       {
-                           "kind": "OBJECT",
-                           "name": "VolumePage",
-                           "ofType": null
-                       }
-                   ]
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "JobsPage",
-                   "description": "  Job model connection. This connection will return a page of jobs.",
-                   "fields": [
-                       {
-                           "name": "after",
-                           "description": "  Next page token",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSJSON",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "first",
-                           "description": "  Number of items on the single page",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "Int",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "items",
-                           "description": "  List of items on the current page",
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Job",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [
-                       {
-                           "kind": "INTERFACE",
-                           "name": "Page",
-                           "ofType": null
-                       }
-                   ],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "ENUM",
-                   "name": "SortDirection",
-                   "description": null,
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": [
-                       {
-                           "name": "ASC",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "DESC",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "RigsPage",
-                   "description": "  Represents list of Rigs.",
-                   "fields": [
-                       {
-                           "name": "after",
-                           "description": "  Next page token",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSJSON",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "first",
-                           "description": "  Number of items on the single page",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "Int",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "items",
-                           "description": "  List of items on the current page",
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Rig",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [
-                       {
-                           "kind": "INTERFACE",
-                           "name": "Page",
-                           "ofType": null
-                       }
-                   ],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "TakesPage",
-                   "description": "  Take model connection. This connection will return a page of takes.",
-                   "fields": [
-                       {
-                           "name": "after",
-                           "description": "  Next token (if any)",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSJSON",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "first",
-                           "description": "  Number of elements in a single page",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "Int",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "items",
-                           "description": "  List of takes in this page",
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Take",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [
-                       {
-                           "kind": "INTERFACE",
-                           "name": "Page",
-                           "ofType": null
-                       }
-                   ],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "VolumePage",
-                   "description": "  Volume model connection. This connection will return a page of volumes.",
-                   "fields": [
-                       {
-                           "name": "after",
-                           "description": "  Next page token",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSJSON",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "first",
-                           "description": "  Number of items on the single page",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "Int",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "items",
-                           "description": "  List of items on the current page",
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "UNION",
-                                   "name": "Volume",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [
-                       {
-                           "kind": "INTERFACE",
-                           "name": "Page",
-                           "ofType": null
-                       }
-                   ],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "Mutation",
-                   "description": "  List of available mutations in UGC API.",
-                   "fields": [
-                       {
-                           "name": "createFile",
-                           "description": "  Create a file with given type (extension) of the file. For example: to create an mp4 file in the system, use `createFile(type: 'mp4')` mutation.",
-                           "args": [
-                               {
-                                   "name": "type",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "String",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "metadata",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "AWSJSON",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "name",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "String",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "File",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "createMultiCamJob",
-                           "description": "  Initialize processing a job to generate animation from a take.",
-                           "args": [
-                               {
-                                   "name": "takeId",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "String",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "metadata",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "AWSJSON",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "name",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "String",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "numberOfActors",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "Int",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "options",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "INPUT_OBJECT",
-                                       "name": "OptionsInput",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "outputs",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "LIST",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "ENUM",
-                                           "name": "OutputType",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "rig",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "String",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Job",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "createMultiCamTake",
-                           "description": "  Create a take from an existing files for multiple cameras.",
-                           "args": [
-                               {
-                                   "name": "sources",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "LIST",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "NON_NULL",
-                                           "name": null,
-                                           "ofType": {
-                                               "kind": "INPUT_OBJECT",
-                                               "name": "SourceInput",
-                                               "ofType": null
-                                           }
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "syncMethod",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "INPUT_OBJECT",
-                                       "name": "SyncMethodInput",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "metadata",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "AWSJSON",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "name",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "String",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "volumeId",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "String",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Take",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "createSingleCamJob",
-                           "description": "  Initialize processing a job to generate animation from a take.",
-                           "args": [
-                               {
-                                   "name": "takeId",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "String",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "metadata",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "AWSJSON",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "name",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "String",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "options",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "INPUT_OBJECT",
-                                       "name": "OptionsInput",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "outputs",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "LIST",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "ENUM",
-                                           "name": "OutputType",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Job",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "createSingleCamTake",
-                           "description": "  Create take from a single camera.",
-                           "args": [
-                               {
-                                   "name": "sources",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "LIST",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "NON_NULL",
-                                           "name": null,
-                                           "ofType": {
-                                               "kind": "INPUT_OBJECT",
-                                               "name": "SourceInput",
-                                               "ofType": null
-                                           }
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "metadata",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "AWSJSON",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "name",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "String",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Take",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "createVolumeWithHuman",
-                           "description": "  Create a volume using a human.",
-                           "args": [
-                               {
-                                   "name": "sources",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "LIST",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "NON_NULL",
-                                           "name": null,
-                                           "ofType": {
-                                               "kind": "INPUT_OBJECT",
-                                               "name": "SourceInput",
-                                               "ofType": null
-                                           }
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "syncMethod",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "INPUT_OBJECT",
-                                       "name": "SyncMethodInput",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "humanHeight",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "Float",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "areaType",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "ENUM",
-                                           "name": "AreaType",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "metadata",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "AWSJSON",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "name",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "String",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "HumanVolume",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "generateShareCode",
-                           "description": "  Generate a share code for a job output. This is typically used to share the output of a job with other users (example: fbx and mp4 output files).",
-                           "args": [
-                               {
-                                   "name": "fileId",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "String",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "ShareCode",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "updateClient",
-                           "description": "  Update client properties.",
-                           "args": [
-                               {
-                                   "name": "metadata",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "AWSJSON",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Client",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "updateFile",
-                           "description": "  Update a file. Currently, only updating metadata for a file is supported.",
-                           "args": [
-                               {
-                                   "name": "id",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "String",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "metadata",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "AWSJSON",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "name",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "String",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "File",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "updateJob",
-                           "description": "  Update a job. Currently, only updating metadata for a job is supported.",
-                           "args": [
-                               {
-                                   "name": "id",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "String",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "metadata",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "AWSJSON",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "name",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "String",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Job",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "updateTake",
-                           "description": "  Update a take. Currently, only updating metadata for a take is supported.",
-                           "args": [
-                               {
-                                   "name": "id",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "String",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "metadata",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "AWSJSON",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "name",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "String",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Take",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "upsertWebhookEndpoint",
-                           "description": "  Perform an upsert operation on a webhook endpoint.",
-                           "args": [
-                               {
-                                   "name": "description",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "String",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "events",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "LIST",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "NON_NULL",
-                                           "name": null,
-                                           "ofType": {
-                                               "kind": "SCALAR",
-                                               "name": "String",
-                                               "ofType": null
-                                           }
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "metadata",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "AWSJSON",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "uid",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "String",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "url",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "SCALAR",
-                                           "name": "String",
-                                           "ofType": null
-                                       }
-                                   },
-                                   "defaultValue": null
-                               },
-                               {
-                                   "name": "secret",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "String",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": null
-                               }
-                           ],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "WebhookEndpoint",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "INPUT_OBJECT",
-                   "name": "OptionsInput",
-                   "description": "  Options input for a multicam run",
-                   "fields": null,
-                   "inputFields": [
-                       {
-                           "name": "floorPlane",
-                           "description": "  Floor Plane",
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "Boolean",
-                               "ofType": null
-                           },
-                           "defaultValue": null
-                       },
-                       {
-                           "name": "trackBall",
-                           "description": "  Track Ball",
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "Boolean",
-                               "ofType": null
-                           },
-                           "defaultValue": null
-                       },
-                       {
-                           "name": "trackFingers",
-                           "description": "  Track Fingers",
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "Boolean",
-                               "ofType": null
-                           },
-                           "defaultValue": null
-                       },
-                       {
-                           "name": "trackJerseyNumbers",
-                           "description": "  Track Jersey Numbers",
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "Boolean",
-                               "ofType": null
-                           },
-                           "defaultValue": null
-                       }
-                   ],
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "ENUM",
-                   "name": "OutputType",
-                   "description": null,
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": [
-                       {
-                           "name": "ALL_BVH",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "ALL_C3D",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "ALL_FBX",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "ALL_GLB",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "ALL_USDC",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "ALL_USDZ",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "MAIN_BLEND",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "MAIN_FBX",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "MAIN_GLB",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "MAIN_USDC",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "MAIN_USDZ",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "MOTION_DATA",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "RENDER_OVERLAY_VIDEO",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "RENDER_VIDEO",
-                           "description": null,
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "INPUT_OBJECT",
-                   "name": "SourceInput",
-                   "description": "  The source device, file and camera settings to use for a take.",
-                   "fields": null,
-                   "inputFields": [
-                       {
-                           "name": "cameraSettings",
-                           "description": "  Settings for the camera that was used to capture this source.",
-                           "type": {
-                               "kind": "INPUT_OBJECT",
-                               "name": "CameraSettingsInput",
-                               "ofType": null
-                           },
-                           "defaultValue": null
-                       },
-                       {
-                           "name": "clipWindow",
-                           "description": "  The clip window that should be processed. If not provided the entire source will be processed.",
-                           "type": {
-                               "kind": "INPUT_OBJECT",
-                               "name": "ClipWindowInput",
-                               "ofType": null
-                           },
-                           "defaultValue": null
-                       },
-                       {
-                           "name": "deviceLabel",
-                           "description": "  A user defined label for the device this source input was captured on.",
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       },
-                       {
-                           "name": "fileId",
-                           "description": "  Reference to the file object of this source.",
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       },
-                       {
-                           "name": "format",
-                           "description": "  The file format of the source.",
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "ENUM",
-                                   "name": "SourceFormat",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       }
-                   ],
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "INPUT_OBJECT",
-                   "name": "CameraSettingsInput",
-                   "description": "  The camera settings for the source input.",
-                   "fields": null,
-                   "inputFields": [
-                       {
-                           "name": "lens",
-                           "description": "  The name of the lens that was used to create the capture inputs.",
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       }
-                   ],
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "INPUT_OBJECT",
-                   "name": "ClipWindowInput",
-                   "description": "  The start and end time of the clip window that should be processed. startTime should be before endTime.",
-                   "fields": null,
-                   "inputFields": [
-                       {
-                           "name": "endTime",
-                           "description": "  The end time of the clip window to be processed.",
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "Float",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       },
-                       {
-                           "name": "startTime",
-                           "description": "  The start time of the clip window to be processed.",
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "Float",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       }
-                   ],
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "INPUT_OBJECT",
-                   "name": "SyncMethodInput",
-                   "description": "  The type of sync method. If not provided it is assumed that all source inputs are fully synced.",
-                   "fields": null,
-                   "inputFields": [
-                       {
-                           "name": "clapWindow",
-                           "description": "  The input sources were synced via a clap.",
-                           "type": {
-                               "kind": "INPUT_OBJECT",
-                               "name": "ClapWindowInput",
-                               "ofType": null
-                           },
-                           "defaultValue": null
-                       },
-                       {
-                           "name": "timecodeSync",
-                           "description": "  The input sources were synced via a timecode.",
-                           "type": {
-                               "kind": "INPUT_OBJECT",
-                               "name": "TimeCodeSyncInput",
-                               "ofType": null
-                           },
-                           "defaultValue": null
-                       }
-                   ],
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "INPUT_OBJECT",
-                   "name": "ClapWindowInput",
-                   "description": "  The start and end time of the clap window that should be used for syncing sources. startTime should be before endTime",
-                   "fields": null,
-                   "inputFields": [
-                       {
-                           "name": "endTime",
-                           "description": "  The end time of the clap window that was used to sync the input sources.",
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "Float",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       },
-                       {
-                           "name": "startTime",
-                           "description": "  The start time of the clap window that was used to sync the input sources.",
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "Float",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       }
-                   ],
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "INPUT_OBJECT",
-                   "name": "TimeCodeSyncInput",
-                   "description": "  Are the source files synced via a timecode",
-                   "fields": null,
-                   "inputFields": [
-                       {
-                           "name": "useTimecode",
-                           "description": "  The source inputs are timecode synced.",
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "Boolean",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       }
-                   ],
-                   "interfaces": null,
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "ShareCode",
-                   "description": "  Represents a ShareCode associated to a file in UGC API. This is usually generated for a job output.",
-                   "fields": [
-                       {
-                           "name": "code",
-                           "description": "  Share code value.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "created",
-                           "description": "  Datetime at which the share code was created.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSDateTime",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "expires",
-                           "description": "  The share code will expire at.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSDateTime",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "file",
-                           "description": "  File associated to the share code.",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "File",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "url",
-                           "description": "  Encoded url with code to download the file.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSURL",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [
-                       {
-                           "kind": "INTERFACE",
-                           "name": "Timestamped",
-                           "ofType": null
-                       }
-                   ],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "WebhookEndpoint",
-                   "description": "  Webhook endpoint represents a URL which will be called when an event occurs.",
-                   "fields": [
-                       {
-                           "name": "client",
-                           "description": "  Associated client account which created this webhook endpoint.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "Client",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "description",
-                           "description": "  Description of the webhook endpoint. This is optional.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "events",
-                           "description": "  Events to be subscribed to. This is required to perform an upsert operation.",
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "NON_NULL",
-                                   "name": null,
-                                   "ofType": {
-                                       "kind": "SCALAR",
-                                       "name": "String",
-                                       "ofType": null
-                                   }
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "metadata",
-                           "description": "  Metadata to be associated with this webhook endpoint. This is optional.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "AWSJSON",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "secret",
-                           "description": "  Secret to be used to sign the payload. This is optional.",
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "uid",
-                           "description": "  Unique identifier for the webhook endpoint. This is required to perform an upsert operation.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "url",
-                           "description": "  URL of the webhook endpoint. This is required to perform an upsert operation.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "__Schema",
-                   "description": "A GraphQL Introspection defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, the entry points for query, mutation, and subscription operations.",
-                   "fields": [
-                       {
-                           "name": "types",
-                           "description": "A list of all types supported by this server.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "LIST",
-                                   "name": null,
-                                   "ofType": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "OBJECT",
-                                           "name": "__Type",
-                                           "ofType": null
-                                       }
-                                   }
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "queryType",
-                           "description": "The type that query operations will be rooted at.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "__Type",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "mutationType",
-                           "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "__Type",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "directives",
-                           "description": "'A list of all directives supported by this server.",
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "LIST",
-                                   "name": null,
-                                   "ofType": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "OBJECT",
-                                           "name": "__Directive",
-                                           "ofType": null
-                                       }
-                                   }
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "subscriptionType",
-                           "description": "'If this server support subscription, the type that subscription operations will be rooted at.",
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "__Type",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "__Type",
-                   "description": null,
-                   "fields": [
-                       {
-                           "name": "kind",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "ENUM",
-                                   "name": "__TypeKind",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "name",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "description",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "fields",
-                           "description": null,
-                           "args": [
-                               {
-                                   "name": "includeDeprecated",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "Boolean",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": "false"
-                               }
-                           ],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "NON_NULL",
-                                   "name": null,
-                                   "ofType": {
-                                       "kind": "OBJECT",
-                                       "name": "__Field",
-                                       "ofType": null
-                                   }
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "interfaces",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "NON_NULL",
-                                   "name": null,
-                                   "ofType": {
-                                       "kind": "OBJECT",
-                                       "name": "__Type",
-                                       "ofType": null
-                                   }
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "possibleTypes",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "NON_NULL",
-                                   "name": null,
-                                   "ofType": {
-                                       "kind": "OBJECT",
-                                       "name": "__Type",
-                                       "ofType": null
-                                   }
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "enumValues",
-                           "description": null,
-                           "args": [
-                               {
-                                   "name": "includeDeprecated",
-                                   "description": null,
-                                   "type": {
-                                       "kind": "SCALAR",
-                                       "name": "Boolean",
-                                       "ofType": null
-                                   },
-                                   "defaultValue": "false"
-                               }
-                           ],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "NON_NULL",
-                                   "name": null,
-                                   "ofType": {
-                                       "kind": "OBJECT",
-                                       "name": "__EnumValue",
-                                       "ofType": null
-                                   }
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "inputFields",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "NON_NULL",
-                                   "name": null,
-                                   "ofType": {
-                                       "kind": "OBJECT",
-                                       "name": "__InputValue",
-                                       "ofType": null
-                                   }
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "ofType",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "OBJECT",
-                               "name": "__Type",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "ENUM",
-                   "name": "__TypeKind",
-                   "description": "An enum describing what kind of type a given __Type is",
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": [
-                       {
-                           "name": "SCALAR",
-                           "description": "Indicates this type is a scalar.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "OBJECT",
-                           "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "INTERFACE",
-                           "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "UNION",
-                           "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "ENUM",
-                           "description": "Indicates this type is an enum. `enumValues` is a valid field.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "INPUT_OBJECT",
-                           "description": "Indicates this type is an input object. `inputFields` is a valid field.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "LIST",
-                           "description": "Indicates this type is a list. `ofType` is a valid field.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "NON_NULL",
-                           "description": "Indicates this type is a non-null. `ofType` is a valid field.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "__Field",
-                   "description": null,
-                   "fields": [
-                       {
-                           "name": "name",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "description",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "args",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "LIST",
-                                   "name": null,
-                                   "ofType": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "OBJECT",
-                                           "name": "__InputValue",
-                                           "ofType": null
-                                       }
-                                   }
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "type",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "__Type",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "isDeprecated",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "Boolean",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "deprecationReason",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "__InputValue",
-                   "description": null,
-                   "fields": [
-                       {
-                           "name": "name",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "description",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "type",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "OBJECT",
-                                   "name": "__Type",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "defaultValue",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "__EnumValue",
-                   "description": null,
-                   "fields": [
-                       {
-                           "name": "name",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "description",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "isDeprecated",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "Boolean",
-                                   "ofType": null
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "deprecationReason",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "OBJECT",
-                   "name": "__Directive",
-                   "description": null,
-                   "fields": [
-                       {
-                           "name": "name",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "description",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "locations",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "NON_NULL",
-                                   "name": null,
-                                   "ofType": {
-                                       "kind": "ENUM",
-                                       "name": "__DirectiveLocation",
-                                       "ofType": null
-                                   }
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "args",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "LIST",
-                                   "name": null,
-                                   "ofType": {
-                                       "kind": "NON_NULL",
-                                       "name": null,
-                                       "ofType": {
-                                           "kind": "OBJECT",
-                                           "name": "__InputValue",
-                                           "ofType": null
-                                       }
-                                   }
-                               }
-                           },
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "onOperation",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "Boolean",
-                               "ofType": null
-                           },
-                           "isDeprecated": true,
-                           "deprecationReason": "Use `locations`."
-                       },
-                       {
-                           "name": "onFragment",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "Boolean",
-                               "ofType": null
-                           },
-                           "isDeprecated": true,
-                           "deprecationReason": "Use `locations`."
-                       },
-                       {
-                           "name": "onField",
-                           "description": null,
-                           "args": [],
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "Boolean",
-                               "ofType": null
-                           },
-                           "isDeprecated": true,
-                           "deprecationReason": "Use `locations`."
-                       }
-                   ],
-                   "inputFields": null,
-                   "interfaces": [],
-                   "enumValues": null,
-                   "possibleTypes": null
-               },
-               {
-                   "kind": "ENUM",
-                   "name": "__DirectiveLocation",
-                   "description": "An enum describing valid locations where a directive can be placed",
-                   "fields": null,
-                   "inputFields": null,
-                   "interfaces": null,
-                   "enumValues": [
-                       {
-                           "name": "QUERY",
-                           "description": "Indicates the directive is valid on queries.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "MUTATION",
-                           "description": "Indicates the directive is valid on mutations.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "FIELD",
-                           "description": "Indicates the directive is valid on fields.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "FRAGMENT_DEFINITION",
-                           "description": "Indicates the directive is valid on fragment definitions.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "FRAGMENT_SPREAD",
-                           "description": "Indicates the directive is valid on fragment spreads.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "INLINE_FRAGMENT",
-                           "description": "Indicates the directive is valid on inline fragments.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "SCHEMA",
-                           "description": "Indicates the directive is valid on a schema SDL definition.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "SCALAR",
-                           "description": "Indicates the directive is valid on a scalar SDL definition.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "OBJECT",
-                           "description": "Indicates the directive is valid on an object SDL definition.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "FIELD_DEFINITION",
-                           "description": "Indicates the directive is valid on a field SDL definition.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "ARGUMENT_DEFINITION",
-                           "description": "Indicates the directive is valid on a field argument SDL definition.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "INTERFACE",
-                           "description": "Indicates the directive is valid on an interface SDL definition.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "UNION",
-                           "description": "Indicates the directive is valid on an union SDL definition.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "ENUM",
-                           "description": "Indicates the directive is valid on an enum SDL definition.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "ENUM_VALUE",
-                           "description": "Indicates the directive is valid on an enum value SDL definition.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "INPUT_OBJECT",
-                           "description": "Indicates the directive is valid on an input object SDL definition.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       },
-                       {
-                           "name": "INPUT_FIELD_DEFINITION",
-                           "description": "Indicates the directive is valid on an input object field SDL definition.",
-                           "isDeprecated": false,
-                           "deprecationReason": null
-                       }
-                   ],
-                   "possibleTypes": null
-               }
-           ],
-           "directives": [
-               {
-                   "name": "include",
-                   "description": "Directs the executor to include this field or fragment only when the `if` argument is true",
-                   "locations": [
-                       "FIELD",
-                       "FRAGMENT_SPREAD",
-                       "INLINE_FRAGMENT"
-                   ],
-                   "args": [
-                       {
-                           "name": "if",
-                           "description": "Included when true.",
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "Boolean",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       }
-                   ]
-               },
-               {
-                   "name": "skip",
-                   "description": "Directs the executor to skip this field or fragment when the `if`'argument is true.",
-                   "locations": [
-                       "FIELD",
-                       "FRAGMENT_SPREAD",
-                       "INLINE_FRAGMENT"
-                   ],
-                   "args": [
-                       {
-                           "name": "if",
-                           "description": "Skipped when true.",
-                           "type": {
-                               "kind": "NON_NULL",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "Boolean",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       }
-                   ]
-               },
-               {
-                   "name": "defer",
-                   "description": "This directive allows results to be deferred during execution",
-                   "locations": [
-                       "FIELD"
-                   ],
-                   "args": []
-               },
-               {
-                   "name": "deprecated",
-                   "description": null,
-                   "locations": [
-                       "FIELD_DEFINITION",
-                       "ENUM_VALUE"
-                   ],
-                   "args": [
-                       {
-                           "name": "reason",
-                           "description": null,
-                           "type": {
-                               "kind": "SCALAR",
-                               "name": "String",
-                               "ofType": null
-                           },
-                           "defaultValue": "\"No longer supported\""
-                       }
-                   ]
-               },
-               {
-                   "name": "aws_subscribe",
-                   "description": "Tells the service which mutation triggers this subscription.",
-                   "locations": [
-                       "FIELD_DEFINITION"
-                   ],
-                   "args": [
-                       {
-                           "name": "mutations",
-                           "description": "List of mutations which will trigger this subscription when they are called.",
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       }
-                   ]
-               },
-               {
-                   "name": "aws_auth",
-                   "description": "Directs the schema to enforce authorization on a field",
-                   "locations": [
-                       "FIELD_DEFINITION"
-                   ],
-                   "args": [
-                       {
-                           "name": "cognito_groups",
-                           "description": "List of cognito user pool groups which have access on this field",
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       }
-                   ]
-               },
-               {
-                   "name": "aws_api_key",
-                   "description": "Tells the service this field/object has access authorized by an API key.",
-                   "locations": [
-                       "OBJECT",
-                       "FIELD_DEFINITION"
-                   ],
-                   "args": []
-               },
-               {
-                   "name": "aws_cognito_user_pools",
-                   "description": "Tells the service this field/object has access authorized by a Cognito User Pools token.",
-                   "locations": [
-                       "OBJECT",
-                       "FIELD_DEFINITION"
-                   ],
-                   "args": [
-                       {
-                           "name": "cognito_groups",
-                           "description": "List of cognito user pool groups which have access on this field",
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       }
-                   ]
-               },
-               {
-                   "name": "aws_iam",
-                   "description": "Tells the service this field/object has access authorized by sigv4 signing.",
-                   "locations": [
-                       "OBJECT",
-                       "FIELD_DEFINITION"
-                   ],
-                   "args": []
-               },
-               {
-                   "name": "aws_publish",
-                   "description": "Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
-                   "locations": [
-                       "FIELD_DEFINITION"
-                   ],
-                   "args": [
-                       {
-                           "name": "subscriptions",
-                           "description": "List of subscriptions which will be published to when this mutation is called.",
-                           "type": {
-                               "kind": "LIST",
-                               "name": null,
-                               "ofType": {
-                                   "kind": "SCALAR",
-                                   "name": "String",
-                                   "ofType": null
-                               }
-                           },
-                           "defaultValue": null
-                       }
-                   ]
-               },
-               {
-                   "name": "aws_oidc",
-                   "description": "Tells the service this field/object has access authorized by an OIDC token.",
-                   "locations": [
-                       "OBJECT",
-                       "FIELD_DEFINITION"
-                   ],
-                   "args": []
-               },
-               {
-                   "name": "aws_lambda",
-                   "description": "Tells the service this field/object has access authorized by a Lambda Authorizer.",
-                   "locations": [
-                       "OBJECT",
-                       "FIELD_DEFINITION"
-                   ],
-                   "args": []
-               }
-           ]
-       }
+   "data":{
+      "__schema":{
+         "queryType":{
+            "name":"Query"
+         },
+         "mutationType":{
+            "name":"Mutation"
+         },
+         "subscriptionType":null,
+         "types":[
+            {
+               "kind":"OBJECT",
+               "name":"Query",
+               "description":"  List of available queries in UGC API.",
+               "fields":[
+                  {
+                     "name":"client",
+                     "description":"  Returns the current client details.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Client",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"getFile",
+                     "description":"  Get file details with given file id.",
+                     "args":[
+                        {
+                           "name":"fileId",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"ID",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"File",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"getJob",
+                     "description":"  Get job details from given job id.",
+                     "args":[
+                        {
+                           "name":"jobId",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"ID",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Job",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"getTake",
+                     "description":"  Get a take with given id.",
+                     "args":[
+                        {
+                           "name":"takeId",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"ID",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Take",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"getVolume",
+                     "description":"  Get a volume with the given id.",
+                     "args":[
+                        {
+                           "name":"id",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"ID",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"UNION",
+                           "name":"Volume",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"listCameraSettings",
+                     "description":"  Get a list of camera settings",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"CameraSettingsPage",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"listJobs",
+                     "description":"  Get a list of jobs.",
+                     "args":[
+                        {
+                           "name":"first",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"Int",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"after",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"AWSJSON",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"sortDirection",
+                           "description":null,
+                           "type":{
+                              "kind":"ENUM",
+                              "name":"SortDirection",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"takeId",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"String",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"JobsPage",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"listRigs",
+                     "description":"  Get a list of all available rigs.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"RigsPage",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"listTakes",
+                     "description":"  Get a list of takes.",
+                     "args":[
+                        {
+                           "name":"first",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"Int",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"after",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"AWSJSON",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"sortDirection",
+                           "description":null,
+                           "type":{
+                              "kind":"ENUM",
+                              "name":"SortDirection",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"TakesPage",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"listVolumes",
+                     "description":"  Get a list of volumes.",
+                     "args":[
+                        {
+                           "name":"first",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"Int",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"after",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"AWSJSON",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"sortDirection",
+                           "description":null,
+                           "type":{
+                              "kind":"ENUM",
+                              "name":"SortDirection",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"VolumePage",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"Client",
+               "description":"  Representation of a Client account.",
+               "fields":[
+                  {
+                     "name":"created",
+                     "description":"  Datetime at which the Client was created.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"AWSDateTime",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"id",
+                     "description":"  Unique identifier for this client.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"ID",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"metadata",
+                     "description":"  Metadata for the client to store any key value pairs - json validation done by AWS",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSJSON",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"name",
+                     "description":"  Name associated to this client.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"portal",
+                     "description":"  Portal url associated to this client.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSURL",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+                  {
+                     "kind":"INTERFACE",
+                     "name":"Identifier",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"INTERFACE",
+                     "name":"Timestamped",
+                     "ofType":null
+                  }
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"SCALAR",
+               "name":"AWSDateTime",
+               "description":"The `AWSDateTime` scalar type provided by AWS AppSync, represents a valid ***extended*** [ISO 8601 DateTime](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) string. In other words, this scalar type accepts datetime strings of the form `YYYY-MM-DDThh:mm:ss.SSSZ`.  The scalar can also accept \"negative years\" of the form `-YYYY` which correspond to years before `0000`. For example, \"**-2017-01-01T00:00Z**\" and \"**-9999-01-01T00:00Z**\" are both valid datetime strings.  The field after the two digit seconds field is a nanoseconds field. It can accept between 1 and 9 digits. So, for example, \"**1970-01-01T12:00:00.2Z**\", \"**1970-01-01T12:00:00.277Z**\" and \"**1970-01-01T12:00:00.123456789Z**\" are all valid datetime strings.  The seconds and nanoseconds fields are optional (the seconds field must be specified if the nanoseconds field is to be used).  The [time zone offset](https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators) is compulsory for this scalar. The time zone offset must either be `Z` (representing the UTC time zone) or be in the format `±hh:mm:ss`. The seconds field in the timezone offset will be considered valid even though it is not part of the ISO 8601 standard.",
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"SCALAR",
+               "name":"ID",
+               "description":"Built-in ID",
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"SCALAR",
+               "name":"AWSJSON",
+               "description":"The `AWSJSON` scalar type provided by AWS AppSync, represents a JSON string that complies with [RFC 8259](https://tools.ietf.org/html/rfc8259).  Maps like \"**{\\\\\"upvotes\\\\\": 10}**\", lists like \"**[1,2,3]**\", and scalar values like \"**\\\\\"AWSJSON example string\\\\\"**\", \"**1**\", and \"**true**\" are accepted as valid JSON and will automatically be parsed and loaded in the resolver mapping templates as Maps, Lists, or Scalar values rather than as the literal input strings.  Invalid JSON strings like \"**{a: 1}**\", \"**{'a': 1}**\" and \"**Unquoted string**\" will throw GraphQL validation errors.",
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"SCALAR",
+               "name":"String",
+               "description":"Built-in String",
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"SCALAR",
+               "name":"AWSURL",
+               "description":"The `AWSURL` scalar type provided by AWS AppSync, represents a valid URL string (Ex: <https://www.amazon.com/>). The URL may use any scheme and may also be a local URL (Ex: <http://localhost/>).  URLs without schemes like \"**amazon.com**\" or \"**www.amazon.com**\" are considered invalid. URLs which contain double slashes (two consecutive forward slashes) in their path are also considered invalid.",
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"INTERFACE",
+               "name":"Identifier",
+               "description":"  Implement this interface to add an identifier to your schema",
+               "fields":[
+                  {
+                     "name":"id",
+                     "description":"  Unique identifier.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"ID",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":[
+                  {
+                     "kind":"OBJECT",
+                     "name":"Client",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"OBJECT",
+                     "name":"File",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"OBJECT",
+                     "name":"Job",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"OBJECT",
+                     "name":"Take",
+                     "ofType":null
+                  }
+               ]
+            },
+            {
+               "kind":"INTERFACE",
+               "name":"Timestamped",
+               "description":"  Implement this interface to make your schema timestampable",
+               "fields":[
+                  {
+                     "name":"created",
+                     "description":"  The child type should define this attribute.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSDateTime",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":[
+                  {
+                     "kind":"OBJECT",
+                     "name":"Client",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"OBJECT",
+                     "name":"File",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"OBJECT",
+                     "name":"Job",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"OBJECT",
+                     "name":"Take",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"OBJECT",
+                     "name":"ShareCode",
+                     "ofType":null
+                  }
+               ]
+            },
+            {
+               "kind":"OBJECT",
+               "name":"File",
+               "description":"  Represents a File in UGC API.",
+               "fields":[
+                  {
+                     "name":"client",
+                     "description":"  Associated client account which created this file.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"Client",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"created",
+                     "description":"  Datetime at which the file was created.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSDateTime",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"id",
+                     "description":"  Unique identifier for a File.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"ID",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"metadata",
+                     "description":"  Metadata for the client to store any key value pairs - json validation done by AWS",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSJSON",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"name",
+                     "description":"  Name of the file.Returns null if no name present.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"presignedUrl",
+                     "description":"  Url to upload/download the file. When creating a file, this attribute will return a upload url. Otherwise, this attribute will represent a download url.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSURL",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"thumbnailUrl",
+                     "description":"  The url of the thumbnail file. Returns null if no thumbnail present",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSURL",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"type",
+                     "description":"  Type (extension) of a file. Example: mp4, mov, avi etc.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+                  {
+                     "kind":"INTERFACE",
+                     "name":"Identifier",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"INTERFACE",
+                     "name":"Timestamped",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"INTERFACE",
+                     "name":"InternalFileSchema",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"INTERFACE",
+                     "name":"ClientOwner",
+                     "ofType":null
+                  }
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"INTERFACE",
+               "name":"InternalFileSchema",
+               "description":"  Implement this interface to add internal file service structure to your schema",
+               "fields":[
+                  {
+                     "name":"presignedUrl",
+                     "description":"  Url to upload/download the file. When creating a file, this attribute will return a upload url. Otherwise, this attribute will represent a download url.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSURL",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"type",
+                     "description":"  Type (extension) of a file. Example: mp4, mov, avi etc.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":[
+                  {
+                     "kind":"OBJECT",
+                     "name":"File",
+                     "ofType":null
+                  }
+               ]
+            },
+            {
+               "kind":"INTERFACE",
+               "name":"ClientOwner",
+               "description":"  Implement this interface if your schema has a client owner",
+               "fields":[
+                  {
+                     "name":"client",
+                     "description":"  Reference to the associated Client owner.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"Client",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":[
+                  {
+                     "kind":"OBJECT",
+                     "name":"File",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"OBJECT",
+                     "name":"Job",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"OBJECT",
+                     "name":"Take",
+                     "ofType":null
+                  }
+               ]
+            },
+            {
+               "kind":"OBJECT",
+               "name":"Job",
+               "description":"  Represents an animation job for a take",
+               "fields":[
+                  {
+                     "name":"client",
+                     "description":"  Client owner of this job",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Client",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"created",
+                     "description":"  Datetime at which the job was created",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSDateTime",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"id",
+                     "description":"  Unique identifier for the job",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"ID",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"metadata",
+                     "description":"  Metadata json field where the client can store any key value pair",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSJSON",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"name",
+                     "description":"  Name of the job.Returns null if no name present.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"outputs",
+                     "description":"  Outputs of this job",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"AdditionalFile",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"rig",
+                     "description":"  Name of the rig to use. If not provided, the default rig will be used",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"Rig",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"state",
+                     "description":"  Current status of the job",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"take",
+                     "description":"  Reference to the original take",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"Take",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+                  {
+                     "kind":"INTERFACE",
+                     "name":"Identifier",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"INTERFACE",
+                     "name":"Timestamped",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"INTERFACE",
+                     "name":"ClientOwner",
+                     "ofType":null
+                  }
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"AdditionalFile",
+               "description":"  An additional file which may be attached to the take",
+               "fields":[
+                  {
+                     "name":"file",
+                     "description":"  Reference to the additional file object",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"File",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"format",
+                     "description":"  Type of additional file",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"key",
+                     "description":"  Type of additional file",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"Rig",
+               "description":"  Represents the rig details attached to a particular job.",
+               "fields":[
+                  {
+                     "name":"name",
+                     "description":"  The name of the rig that was used to create the job.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"Take",
+               "description":"  Representation of a take",
+               "fields":[
+                  {
+                     "name":"additionalFiles",
+                     "description":"  Optional additional files for this take",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"AdditionalFile",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"client",
+                     "description":"  Reference to the client owner of the take",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Client",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"created",
+                     "description":"  Datetime string at which the take was created",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"AWSDateTime",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"id",
+                     "description":"   Unique id of a take ",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"ID",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"metadata",
+                     "description":"  Metadata for the client to store any key value pairs - json validation done by AWS",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSJSON",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"name",
+                     "description":"  Name of the take. Returns null if no name present.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"sources",
+                     "description":"  Sources associated with the take.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Source",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"syncMethod",
+                     "description":"  The sync method for the input sources on this take. If not provided it is assumed that all source inputs are fully synced.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"SyncMethod",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"takeType",
+                     "description":"  Type of the take (this can be either a multiple or singlecam take).",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"ENUM",
+                        "name":"TakeType",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"videoFile",
+                     "description":"  Reference to the video file included with this take",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"File",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"volume",
+                     "description":"  Volume associated with a multicam take.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"UNION",
+                        "name":"Volume",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+                  {
+                     "kind":"INTERFACE",
+                     "name":"Identifier",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"INTERFACE",
+                     "name":"Timestamped",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"INTERFACE",
+                     "name":"ClientOwner",
+                     "ofType":null
+                  }
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"Source",
+               "description":"  The source device, file and camera settings to use for a take.",
+               "fields":[
+                  {
+                     "name":"cameraSettings",
+                     "description":"  Settings for the camera that was used to capture this source.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"CameraSettings",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"clipWindow",
+                     "description":"  The clip window that should be processed. If not provided the entire source will be processed.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"ClipWindow",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"deviceLabel",
+                     "description":"  A user defined label for the device this source input was captured on.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"file",
+                     "description":"  Reference to the file object of this source.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"File",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"format",
+                     "description":"  The file format of the source.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"ENUM",
+                        "name":"SourceFormat",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"CameraSettings",
+               "description":"  The camera settings for the source",
+               "fields":[
+                  {
+                     "name":"lens",
+                     "description":"  The name of the lens that was used to create the capture inputs.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"ClipWindow",
+               "description":"  The start and end time of the clip window that should be processed. startTime should be before endTime.",
+               "fields":[
+                  {
+                     "name":"endTime",
+                     "description":"  The end time of the clip window to be processed.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"Float",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"startTime",
+                     "description":"  The start time of the clip window to be processed.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"Float",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"SCALAR",
+               "name":"Float",
+               "description":"Built-in Float",
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"ENUM",
+               "name":"SourceFormat",
+               "description":null,
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":[
+                  {
+                     "name":"AVI",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"MOV",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"MOVE",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"MP4",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"SyncMethod",
+               "description":"  The type of sync method. If not provided it is assumed that all source inputs are fully synced.",
+               "fields":[
+                  {
+                     "name":"clapWindow",
+                     "description":"  The input sources were synced via a clap.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"ClapWindow",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"timecodeSync",
+                     "description":"  The input sources were synced via a timecode.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"TimeCodeSync",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"ClapWindow",
+               "description":"  The start and end time of the clap window that should be used for syncing sources. startTime should be before endTime",
+               "fields":[
+                  {
+                     "name":"endTime",
+                     "description":"  The end time of the clap window that was used to sync the input sources.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"Float",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"startTime",
+                     "description":"  The start time of the clap window that was used to sync the input sources.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"Float",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"TimeCodeSync",
+               "description":"  Are the source files synced via a timecode",
+               "fields":[
+                  {
+                     "name":"useTimecode",
+                     "description":"  The source inputs are timecode synced.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"Boolean",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"SCALAR",
+               "name":"Boolean",
+               "description":"Built-in Boolean",
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"ENUM",
+               "name":"TakeType",
+               "description":null,
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":[
+                  {
+                     "name":"MULTI_CAM",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"SINGLE_CAM",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "possibleTypes":null
+            },
+            {
+               "kind":"UNION",
+               "name":"Volume",
+               "description":"  A volume used in a multicam take will be one of these types.",
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":[
+                  {
+                     "kind":"OBJECT",
+                     "name":"HumanVolume",
+                     "ofType":null
+                  }
+               ]
+            },
+            {
+               "kind":"OBJECT",
+               "name":"HumanVolume",
+               "description":"  Represents volumes for a multicam take\n A volume that was created using a human.",
+               "fields":[
+                  {
+                     "name":"areaType",
+                     "description":"  Area type of the volume.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"ENUM",
+                        "name":"AreaType",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"client",
+                     "description":"  Reference to the client owner of the volume.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Client",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"created",
+                     "description":"  Datetime at which the volume was created",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"AWSDateTime",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"humanHeight",
+                     "description":"  Height of the human present in the volume.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"Float",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"id",
+                     "description":"  Unique id of a volume. This is the volume job id.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"ID",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"metadata",
+                     "description":"  Metadata for the client to store any key value pairs - json validation done by AWS.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSJSON",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"name",
+                     "description":"  Name of the human volume. Returns null if no name present.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"outputs",
+                     "description":"  Outputs of this volume.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"AdditionalFile",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"sources",
+                     "description":"  Input source files required for creating HumanVolume, sources from at least two cameras are required.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"NON_NULL",
+                           "name":null,
+                           "ofType":{
+                              "kind":"OBJECT",
+                              "name":"Source",
+                              "ofType":null
+                           }
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"state",
+                     "description":"  Current status of the volume processing.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"ENUM",
+                        "name":"JobState",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"ENUM",
+               "name":"AreaType",
+               "description":null,
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":[
+                  {
+                     "name":"LARGE",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"NORMAL",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "possibleTypes":null
+            },
+            {
+               "kind":"ENUM",
+               "name":"JobState",
+               "description":null,
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":[
+                  {
+                     "name":"FAILED",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"FINISHED",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"NOT_STARTED",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"RUNNING",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"CameraSettingsPage",
+               "description":"  CameraSettings model connection. This connection will return a page of camera settings.",
+               "fields":[
+                  {
+                     "name":"after",
+                     "description":"  Next page token",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSJSON",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"first",
+                     "description":"  Number of items on the single page",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"Int",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"items",
+                     "description":"  List of items on the current page",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"CameraSettings",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+                  {
+                     "kind":"INTERFACE",
+                     "name":"Page",
+                     "ofType":null
+                  }
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"SCALAR",
+               "name":"Int",
+               "description":"Built-in Int",
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"INTERFACE",
+               "name":"Page",
+               "description":"  Implement this interface for your schema page",
+               "fields":[
+                  {
+                     "name":"after",
+                     "description":"  Next token for the items to be fetched in the remaining pages.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSJSON",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"first",
+                     "description":"  Items to fetch in a single page. Defaults to 50.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"Int",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":[
+                  {
+                     "kind":"OBJECT",
+                     "name":"CameraSettingsPage",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"OBJECT",
+                     "name":"JobsPage",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"OBJECT",
+                     "name":"RigsPage",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"OBJECT",
+                     "name":"TakesPage",
+                     "ofType":null
+                  },
+                  {
+                     "kind":"OBJECT",
+                     "name":"VolumePage",
+                     "ofType":null
+                  }
+               ]
+            },
+            {
+               "kind":"OBJECT",
+               "name":"JobsPage",
+               "description":"  Job model connection. This connection will return a page of jobs.",
+               "fields":[
+                  {
+                     "name":"after",
+                     "description":"  Next page token",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSJSON",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"first",
+                     "description":"  Number of items on the single page",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"Int",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"items",
+                     "description":"  List of items on the current page",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Job",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+                  {
+                     "kind":"INTERFACE",
+                     "name":"Page",
+                     "ofType":null
+                  }
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"ENUM",
+               "name":"SortDirection",
+               "description":null,
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":[
+                  {
+                     "name":"ASC",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"DESC",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"RigsPage",
+               "description":"  Represents list of Rigs.",
+               "fields":[
+                  {
+                     "name":"after",
+                     "description":"  Next page token",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSJSON",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"first",
+                     "description":"  Number of items on the single page",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"Int",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"items",
+                     "description":"  List of items on the current page",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Rig",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+                  {
+                     "kind":"INTERFACE",
+                     "name":"Page",
+                     "ofType":null
+                  }
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"TakesPage",
+               "description":"  Take model connection. This connection will return a page of takes.",
+               "fields":[
+                  {
+                     "name":"after",
+                     "description":"  Next token (if any)",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSJSON",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"first",
+                     "description":"  Number of elements in a single page",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"Int",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"items",
+                     "description":"  List of takes in this page",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Take",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+                  {
+                     "kind":"INTERFACE",
+                     "name":"Page",
+                     "ofType":null
+                  }
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"VolumePage",
+               "description":"  Volume model connection. This connection will return a page of volumes.",
+               "fields":[
+                  {
+                     "name":"after",
+                     "description":"  Next page token",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSJSON",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"first",
+                     "description":"  Number of items on the single page",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"Int",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"items",
+                     "description":"  List of items on the current page",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"UNION",
+                           "name":"Volume",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+                  {
+                     "kind":"INTERFACE",
+                     "name":"Page",
+                     "ofType":null
+                  }
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"Mutation",
+               "description":"  List of available mutations in UGC API.",
+               "fields":[
+                  {
+                     "name":"createFile",
+                     "description":"  Create a file with given type (extension) of the file. For example: to create an mp4 file in the system, use `createFile(type: 'mp4')` mutation.",
+                     "args":[
+                        {
+                           "name":"type",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"String",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"metadata",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"AWSJSON",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"name",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"String",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"File",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"createMultiCamJob",
+                     "description":"  Initialize processing a job to generate animation from a take.",
+                     "args":[
+                        {
+                           "name":"clipWindow",
+                           "description":null,
+                           "type":{
+                              "kind":"INPUT_OBJECT",
+                              "name":"ClipWindowInput",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"takeId",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"String",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"metadata",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"AWSJSON",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"name",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"String",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"numberOfActors",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"Int",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"options",
+                           "description":null,
+                           "type":{
+                              "kind":"INPUT_OBJECT",
+                              "name":"OptionsInput",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"outputs",
+                           "description":null,
+                           "type":{
+                              "kind":"LIST",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"ENUM",
+                                 "name":"OutputType",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"rig",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"String",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Job",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"createMultiCamTake",
+                     "description":"  Create a take from an existing files for multiple cameras.",
+                     "args":[
+                        {
+                           "name":"sources",
+                           "description":null,
+                           "type":{
+                              "kind":"LIST",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"NON_NULL",
+                                 "name":null,
+                                 "ofType":{
+                                    "kind":"INPUT_OBJECT",
+                                    "name":"SourceInput",
+                                    "ofType":null
+                                 }
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"syncMethod",
+                           "description":null,
+                           "type":{
+                              "kind":"INPUT_OBJECT",
+                              "name":"SyncMethodInput",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"metadata",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"AWSJSON",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"name",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"String",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"volumeId",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"String",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Take",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"createSingleCamJob",
+                     "description":"  Initialize processing a job to generate animation from a take.",
+                     "args":[
+                        {
+                           "name":"clipWindow",
+                           "description":null,
+                           "type":{
+                              "kind":"INPUT_OBJECT",
+                              "name":"ClipWindowInput",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"takeId",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"String",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"metadata",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"AWSJSON",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"name",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"String",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"options",
+                           "description":null,
+                           "type":{
+                              "kind":"INPUT_OBJECT",
+                              "name":"OptionsInput",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"outputs",
+                           "description":null,
+                           "type":{
+                              "kind":"LIST",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"ENUM",
+                                 "name":"OutputType",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Job",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"createSingleCamTake",
+                     "description":"  Create take from a single camera.",
+                     "args":[
+                        {
+                           "name":"sources",
+                           "description":null,
+                           "type":{
+                              "kind":"LIST",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"NON_NULL",
+                                 "name":null,
+                                 "ofType":{
+                                    "kind":"INPUT_OBJECT",
+                                    "name":"SourceInput",
+                                    "ofType":null
+                                 }
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"metadata",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"AWSJSON",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"name",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"String",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Take",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"createVolumeWithHuman",
+                     "description":"  Create a volume using a human.",
+                     "args":[
+                        {
+                           "name":"clipWindow",
+                           "description":null,
+                           "type":{
+                              "kind":"INPUT_OBJECT",
+                              "name":"ClipWindowInput",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"sources",
+                           "description":null,
+                           "type":{
+                              "kind":"LIST",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"NON_NULL",
+                                 "name":null,
+                                 "ofType":{
+                                    "kind":"INPUT_OBJECT",
+                                    "name":"SourceInput",
+                                    "ofType":null
+                                 }
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"syncMethod",
+                           "description":null,
+                           "type":{
+                              "kind":"INPUT_OBJECT",
+                              "name":"SyncMethodInput",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"humanHeight",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"Float",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"areaType",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"ENUM",
+                                 "name":"AreaType",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"metadata",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"AWSJSON",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"name",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"String",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"HumanVolume",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"generateShareCode",
+                     "description":"  Generate a share code for a job output. This is typically used to share the output of a job with other users (example: fbx and mp4 output files).",
+                     "args":[
+                        {
+                           "name":"fileId",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"String",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"ShareCode",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"updateClient",
+                     "description":"  Update client properties.",
+                     "args":[
+                        {
+                           "name":"metadata",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"AWSJSON",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Client",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"updateFile",
+                     "description":"  Update a file. Currently, only updating metadata for a file is supported.",
+                     "args":[
+                        {
+                           "name":"id",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"String",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"metadata",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"AWSJSON",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"name",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"String",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"File",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"updateJob",
+                     "description":"  Update a job. Currently, only updating metadata for a job is supported.",
+                     "args":[
+                        {
+                           "name":"id",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"String",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"metadata",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"AWSJSON",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"name",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"String",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Job",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"updateTake",
+                     "description":"  Update a take. Currently, only updating metadata for a take is supported.",
+                     "args":[
+                        {
+                           "name":"id",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"String",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"metadata",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"AWSJSON",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"name",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"String",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Take",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"upsertWebhookEndpoint",
+                     "description":"  Perform an upsert operation on a webhook endpoint.",
+                     "args":[
+                        {
+                           "name":"description",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"String",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"events",
+                           "description":null,
+                           "type":{
+                              "kind":"LIST",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"NON_NULL",
+                                 "name":null,
+                                 "ofType":{
+                                    "kind":"SCALAR",
+                                    "name":"String",
+                                    "ofType":null
+                                 }
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"metadata",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"AWSJSON",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"uid",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"String",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"url",
+                           "description":null,
+                           "type":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"SCALAR",
+                                 "name":"String",
+                                 "ofType":null
+                              }
+                           },
+                           "defaultValue":null
+                        },
+                        {
+                           "name":"secret",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"String",
+                              "ofType":null
+                           },
+                           "defaultValue":null
+                        }
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"WebhookEndpoint",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"INPUT_OBJECT",
+               "name":"ClipWindowInput",
+               "description":"  The start and end time of the clip window that should be processed. startTime should be before endTime.",
+               "fields":null,
+               "inputFields":[
+                  {
+                     "name":"endTime",
+                     "description":"  The end time of the clip window to be processed.",
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"Float",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  },
+                  {
+                     "name":"startTime",
+                     "description":"  The start time of the clip window to be processed.",
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"Float",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  }
+               ],
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"INPUT_OBJECT",
+               "name":"OptionsInput",
+               "description":"  Options input for a multicam run",
+               "fields":null,
+               "inputFields":[
+                  {
+                     "name":"floorPlane",
+                     "description":"  Floor Plane",
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"Boolean",
+                        "ofType":null
+                     },
+                     "defaultValue":null
+                  },
+                  {
+                     "name":"trackBall",
+                     "description":"  Track Ball",
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"Boolean",
+                        "ofType":null
+                     },
+                     "defaultValue":null
+                  },
+                  {
+                     "name":"trackFingers",
+                     "description":"  Track Fingers",
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"Boolean",
+                        "ofType":null
+                     },
+                     "defaultValue":null
+                  },
+                  {
+                     "name":"trackJerseyNumbers",
+                     "description":"  Track Jersey Numbers",
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"Boolean",
+                        "ofType":null
+                     },
+                     "defaultValue":null
+                  }
+               ],
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"ENUM",
+               "name":"OutputType",
+               "description":null,
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":[
+                  {
+                     "name":"ALL_BVH",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"ALL_C3D",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"ALL_FBX",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"ALL_GLB",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"ALL_USDC",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"ALL_USDZ",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"MAIN_BLEND",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"MAIN_FBX",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"MAIN_GLB",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"MAIN_USDC",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"MAIN_USDZ",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"MOTION_DATA",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"RENDER_OVERLAY_VIDEO",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"RENDER_VIDEO",
+                     "description":null,
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "possibleTypes":null
+            },
+            {
+               "kind":"INPUT_OBJECT",
+               "name":"SourceInput",
+               "description":"  The source device, file and camera settings to use for a take.",
+               "fields":null,
+               "inputFields":[
+                  {
+                     "name":"cameraSettings",
+                     "description":"  Settings for the camera that was used to capture this source.",
+                     "type":{
+                        "kind":"INPUT_OBJECT",
+                        "name":"CameraSettingsInput",
+                        "ofType":null
+                     },
+                     "defaultValue":null
+                  },
+                  {
+                     "name":"clipWindow",
+                     "description":"  The clip window that should be processed. If not provided the entire source will be processed.",
+                     "type":{
+                        "kind":"INPUT_OBJECT",
+                        "name":"ClipWindowInput",
+                        "ofType":null
+                     },
+                     "defaultValue":null
+                  },
+                  {
+                     "name":"deviceLabel",
+                     "description":"  A user defined label for the device this source input was captured on.",
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  },
+                  {
+                     "name":"fileId",
+                     "description":"  Reference to the file object of this source.",
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  },
+                  {
+                     "name":"format",
+                     "description":"  The file format of the source.",
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"ENUM",
+                           "name":"SourceFormat",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  }
+               ],
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"INPUT_OBJECT",
+               "name":"CameraSettingsInput",
+               "description":"  The camera settings for the source input.",
+               "fields":null,
+               "inputFields":[
+                  {
+                     "name":"lens",
+                     "description":"  The name of the lens that was used to create the capture inputs.",
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  }
+               ],
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"INPUT_OBJECT",
+               "name":"SyncMethodInput",
+               "description":"  The type of sync method. If not provided it is assumed that all source inputs are fully synced.",
+               "fields":null,
+               "inputFields":[
+                  {
+                     "name":"clapWindow",
+                     "description":"  The input sources were synced via a clap.",
+                     "type":{
+                        "kind":"INPUT_OBJECT",
+                        "name":"ClapWindowInput",
+                        "ofType":null
+                     },
+                     "defaultValue":null
+                  },
+                  {
+                     "name":"timecodeSync",
+                     "description":"  The input sources were synced via a timecode.",
+                     "type":{
+                        "kind":"INPUT_OBJECT",
+                        "name":"TimeCodeSyncInput",
+                        "ofType":null
+                     },
+                     "defaultValue":null
+                  }
+               ],
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"INPUT_OBJECT",
+               "name":"ClapWindowInput",
+               "description":"  The start and end time of the clap window that should be used for syncing sources. startTime should be before endTime",
+               "fields":null,
+               "inputFields":[
+                  {
+                     "name":"endTime",
+                     "description":"  The end time of the clap window that was used to sync the input sources.",
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"Float",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  },
+                  {
+                     "name":"startTime",
+                     "description":"  The start time of the clap window that was used to sync the input sources.",
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"Float",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  }
+               ],
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"INPUT_OBJECT",
+               "name":"TimeCodeSyncInput",
+               "description":"  Are the source files synced via a timecode",
+               "fields":null,
+               "inputFields":[
+                  {
+                     "name":"useTimecode",
+                     "description":"  The source inputs are timecode synced.",
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"Boolean",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  }
+               ],
+               "interfaces":null,
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"ShareCode",
+               "description":"  Represents a ShareCode associated to a file in UGC API. This is usually generated for a job output.",
+               "fields":[
+                  {
+                     "name":"code",
+                     "description":"  Share code value.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"created",
+                     "description":"  Datetime at which the share code was created.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSDateTime",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"expires",
+                     "description":"  The share code will expire at.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSDateTime",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"file",
+                     "description":"  File associated to the share code.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"File",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"url",
+                     "description":"  Encoded url with code to download the file.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSURL",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+                  {
+                     "kind":"INTERFACE",
+                     "name":"Timestamped",
+                     "ofType":null
+                  }
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"WebhookEndpoint",
+               "description":"  Webhook endpoint represents a URL which will be called when an event occurs.",
+               "fields":[
+                  {
+                     "name":"client",
+                     "description":"  Associated client account which created this webhook endpoint.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"Client",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"description",
+                     "description":"  Description of the webhook endpoint. This is optional.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"events",
+                     "description":"  Events to be subscribed to. This is required to perform an upsert operation.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"NON_NULL",
+                           "name":null,
+                           "ofType":{
+                              "kind":"SCALAR",
+                              "name":"String",
+                              "ofType":null
+                           }
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"metadata",
+                     "description":"  Metadata to be associated with this webhook endpoint. This is optional.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"AWSJSON",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"secret",
+                     "description":"  Secret to be used to sign the payload. This is optional.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"uid",
+                     "description":"  Unique identifier for the webhook endpoint. This is required to perform an upsert operation.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"url",
+                     "description":"  URL of the webhook endpoint. This is required to perform an upsert operation.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"__Schema",
+               "description":"A GraphQL Introspection defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, the entry points for query, mutation, and subscription operations.",
+               "fields":[
+                  {
+                     "name":"types",
+                     "description":"A list of all types supported by this server.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"LIST",
+                           "name":null,
+                           "ofType":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"OBJECT",
+                                 "name":"__Type",
+                                 "ofType":null
+                              }
+                           }
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"queryType",
+                     "description":"The type that query operations will be rooted at.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"__Type",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"mutationType",
+                     "description":"If this server supports mutation, the type that mutation operations will be rooted at.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"__Type",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"directives",
+                     "description":"'A list of all directives supported by this server.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"LIST",
+                           "name":null,
+                           "ofType":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"OBJECT",
+                                 "name":"__Directive",
+                                 "ofType":null
+                              }
+                           }
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"subscriptionType",
+                     "description":"'If this server support subscription, the type that subscription operations will be rooted at.",
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"__Type",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"__Type",
+               "description":null,
+               "fields":[
+                  {
+                     "name":"kind",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"ENUM",
+                           "name":"__TypeKind",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"name",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"description",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"fields",
+                     "description":null,
+                     "args":[
+                        {
+                           "name":"includeDeprecated",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"Boolean",
+                              "ofType":null
+                           },
+                           "defaultValue":"false"
+                        }
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"NON_NULL",
+                           "name":null,
+                           "ofType":{
+                              "kind":"OBJECT",
+                              "name":"__Field",
+                              "ofType":null
+                           }
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"interfaces",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"NON_NULL",
+                           "name":null,
+                           "ofType":{
+                              "kind":"OBJECT",
+                              "name":"__Type",
+                              "ofType":null
+                           }
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"possibleTypes",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"NON_NULL",
+                           "name":null,
+                           "ofType":{
+                              "kind":"OBJECT",
+                              "name":"__Type",
+                              "ofType":null
+                           }
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"enumValues",
+                     "description":null,
+                     "args":[
+                        {
+                           "name":"includeDeprecated",
+                           "description":null,
+                           "type":{
+                              "kind":"SCALAR",
+                              "name":"Boolean",
+                              "ofType":null
+                           },
+                           "defaultValue":"false"
+                        }
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"NON_NULL",
+                           "name":null,
+                           "ofType":{
+                              "kind":"OBJECT",
+                              "name":"__EnumValue",
+                              "ofType":null
+                           }
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"inputFields",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"NON_NULL",
+                           "name":null,
+                           "ofType":{
+                              "kind":"OBJECT",
+                              "name":"__InputValue",
+                              "ofType":null
+                           }
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"ofType",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"OBJECT",
+                        "name":"__Type",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"ENUM",
+               "name":"__TypeKind",
+               "description":"An enum describing what kind of type a given __Type is",
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":[
+                  {
+                     "name":"SCALAR",
+                     "description":"Indicates this type is a scalar.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"OBJECT",
+                     "description":"Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"INTERFACE",
+                     "description":"Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"UNION",
+                     "description":"Indicates this type is a union. `possibleTypes` is a valid field.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"ENUM",
+                     "description":"Indicates this type is an enum. `enumValues` is a valid field.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"INPUT_OBJECT",
+                     "description":"Indicates this type is an input object. `inputFields` is a valid field.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"LIST",
+                     "description":"Indicates this type is a list. `ofType` is a valid field.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"NON_NULL",
+                     "description":"Indicates this type is a non-null. `ofType` is a valid field.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"__Field",
+               "description":null,
+               "fields":[
+                  {
+                     "name":"name",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"description",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"args",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"LIST",
+                           "name":null,
+                           "ofType":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"OBJECT",
+                                 "name":"__InputValue",
+                                 "ofType":null
+                              }
+                           }
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"type",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"__Type",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"isDeprecated",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"Boolean",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"deprecationReason",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"__InputValue",
+               "description":null,
+               "fields":[
+                  {
+                     "name":"name",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"description",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"type",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"OBJECT",
+                           "name":"__Type",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"defaultValue",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"__EnumValue",
+               "description":null,
+               "fields":[
+                  {
+                     "name":"name",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"description",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"isDeprecated",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"Boolean",
+                           "ofType":null
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"deprecationReason",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"OBJECT",
+               "name":"__Directive",
+               "description":null,
+               "fields":[
+                  {
+                     "name":"name",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"description",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"locations",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"NON_NULL",
+                           "name":null,
+                           "ofType":{
+                              "kind":"ENUM",
+                              "name":"__DirectiveLocation",
+                              "ofType":null
+                           }
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"args",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"LIST",
+                           "name":null,
+                           "ofType":{
+                              "kind":"NON_NULL",
+                              "name":null,
+                              "ofType":{
+                                 "kind":"OBJECT",
+                                 "name":"__InputValue",
+                                 "ofType":null
+                              }
+                           }
+                        }
+                     },
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"onOperation",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"Boolean",
+                        "ofType":null
+                     },
+                     "isDeprecated":true,
+                     "deprecationReason":"Use `locations`."
+                  },
+                  {
+                     "name":"onFragment",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"Boolean",
+                        "ofType":null
+                     },
+                     "isDeprecated":true,
+                     "deprecationReason":"Use `locations`."
+                  },
+                  {
+                     "name":"onField",
+                     "description":null,
+                     "args":[
+
+                     ],
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"Boolean",
+                        "ofType":null
+                     },
+                     "isDeprecated":true,
+                     "deprecationReason":"Use `locations`."
+                  }
+               ],
+               "inputFields":null,
+               "interfaces":[
+
+               ],
+               "enumValues":null,
+               "possibleTypes":null
+            },
+            {
+               "kind":"ENUM",
+               "name":"__DirectiveLocation",
+               "description":"An enum describing valid locations where a directive can be placed",
+               "fields":null,
+               "inputFields":null,
+               "interfaces":null,
+               "enumValues":[
+                  {
+                     "name":"QUERY",
+                     "description":"Indicates the directive is valid on queries.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"MUTATION",
+                     "description":"Indicates the directive is valid on mutations.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"FIELD",
+                     "description":"Indicates the directive is valid on fields.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"FRAGMENT_DEFINITION",
+                     "description":"Indicates the directive is valid on fragment definitions.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"FRAGMENT_SPREAD",
+                     "description":"Indicates the directive is valid on fragment spreads.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"INLINE_FRAGMENT",
+                     "description":"Indicates the directive is valid on inline fragments.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"SCHEMA",
+                     "description":"Indicates the directive is valid on a schema SDL definition.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"SCALAR",
+                     "description":"Indicates the directive is valid on a scalar SDL definition.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"OBJECT",
+                     "description":"Indicates the directive is valid on an object SDL definition.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"FIELD_DEFINITION",
+                     "description":"Indicates the directive is valid on a field SDL definition.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"ARGUMENT_DEFINITION",
+                     "description":"Indicates the directive is valid on a field argument SDL definition.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"INTERFACE",
+                     "description":"Indicates the directive is valid on an interface SDL definition.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"UNION",
+                     "description":"Indicates the directive is valid on an union SDL definition.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"ENUM",
+                     "description":"Indicates the directive is valid on an enum SDL definition.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"ENUM_VALUE",
+                     "description":"Indicates the directive is valid on an enum value SDL definition.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"INPUT_OBJECT",
+                     "description":"Indicates the directive is valid on an input object SDL definition.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  },
+                  {
+                     "name":"INPUT_FIELD_DEFINITION",
+                     "description":"Indicates the directive is valid on an input object field SDL definition.",
+                     "isDeprecated":false,
+                     "deprecationReason":null
+                  }
+               ],
+               "possibleTypes":null
+            }
+         ],
+         "directives":[
+            {
+               "name":"include",
+               "description":"Directs the executor to include this field or fragment only when the `if` argument is true",
+               "locations":[
+                  "FIELD",
+                  "FRAGMENT_SPREAD",
+                  "INLINE_FRAGMENT"
+               ],
+               "args":[
+                  {
+                     "name":"if",
+                     "description":"Included when true.",
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"Boolean",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  }
+               ]
+            },
+            {
+               "name":"skip",
+               "description":"Directs the executor to skip this field or fragment when the `if`'argument is true.",
+               "locations":[
+                  "FIELD",
+                  "FRAGMENT_SPREAD",
+                  "INLINE_FRAGMENT"
+               ],
+               "args":[
+                  {
+                     "name":"if",
+                     "description":"Skipped when true.",
+                     "type":{
+                        "kind":"NON_NULL",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"Boolean",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  }
+               ]
+            },
+            {
+               "name":"defer",
+               "description":"This directive allows results to be deferred during execution",
+               "locations":[
+                  "FIELD"
+               ],
+               "args":[
+
+               ]
+            },
+            {
+               "name":"aws_oidc",
+               "description":"Tells the service this field/object has access authorized by an OIDC token.",
+               "locations":[
+                  "OBJECT",
+                  "FIELD_DEFINITION"
+               ],
+               "args":[
+
+               ]
+            },
+            {
+               "name":"deprecated",
+               "description":null,
+               "locations":[
+                  "FIELD_DEFINITION",
+                  "ENUM_VALUE"
+               ],
+               "args":[
+                  {
+                     "name":"reason",
+                     "description":null,
+                     "type":{
+                        "kind":"SCALAR",
+                        "name":"String",
+                        "ofType":null
+                     },
+                     "defaultValue":"\"No longer supported\""
+                  }
+               ]
+            },
+            {
+               "name":"aws_publish",
+               "description":"Tells the service which subscriptions will be published to when this mutation is called. This directive is deprecated use @aws_susbscribe directive instead.",
+               "locations":[
+                  "FIELD_DEFINITION"
+               ],
+               "args":[
+                  {
+                     "name":"subscriptions",
+                     "description":"List of subscriptions which will be published to when this mutation is called.",
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  }
+               ]
+            },
+            {
+               "name":"aws_cognito_user_pools",
+               "description":"Tells the service this field/object has access authorized by a Cognito User Pools token.",
+               "locations":[
+                  "OBJECT",
+                  "FIELD_DEFINITION"
+               ],
+               "args":[
+                  {
+                     "name":"cognito_groups",
+                     "description":"List of cognito user pool groups which have access on this field",
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  }
+               ]
+            },
+            {
+               "name":"aws_api_key",
+               "description":"Tells the service this field/object has access authorized by an API key.",
+               "locations":[
+                  "OBJECT",
+                  "FIELD_DEFINITION"
+               ],
+               "args":[
+
+               ]
+            },
+            {
+               "name":"aws_auth",
+               "description":"Directs the schema to enforce authorization on a field",
+               "locations":[
+                  "FIELD_DEFINITION"
+               ],
+               "args":[
+                  {
+                     "name":"cognito_groups",
+                     "description":"List of cognito user pool groups which have access on this field",
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  }
+               ]
+            },
+            {
+               "name":"aws_iam",
+               "description":"Tells the service this field/object has access authorized by sigv4 signing.",
+               "locations":[
+                  "OBJECT",
+                  "FIELD_DEFINITION"
+               ],
+               "args":[
+
+               ]
+            },
+            {
+               "name":"aws_subscribe",
+               "description":"Tells the service which mutation triggers this subscription.",
+               "locations":[
+                  "FIELD_DEFINITION"
+               ],
+               "args":[
+                  {
+                     "name":"mutations",
+                     "description":"List of mutations which will trigger this subscription when they are called.",
+                     "type":{
+                        "kind":"LIST",
+                        "name":null,
+                        "ofType":{
+                           "kind":"SCALAR",
+                           "name":"String",
+                           "ofType":null
+                        }
+                     },
+                     "defaultValue":null
+                  }
+               ]
+            },
+            {
+               "name":"aws_lambda",
+               "description":"Tells the service this field/object has access authorized by a Lambda Authorizer.",
+               "locations":[
+                  "OBJECT",
+                  "FIELD_DEFINITION"
+               ],
+               "args":[
+
+               ]
+            }
+         ]
+      }
    }
 }

--- a/tests/services/snapshots/snap_test_job.py
+++ b/tests/services/snapshots/snap_test_job.py
@@ -10,7 +10,7 @@ snapshots[
     "TestJobService.test_create_multicam[-None-empty_expand] create_mutation_expand_[]"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -19,6 +19,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -32,6 +33,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -74,7 +76,7 @@ snapshots[
     "TestJobService.test_create_multicam[-None-expand_client] create_mutation_expand_client"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -83,6 +85,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -104,6 +107,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -158,7 +162,7 @@ snapshots[
     "TestJobService.test_create_multicam[-None-expand_outputs] create_mutation_expand_outputs"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -167,6 +171,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -194,6 +199,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -299,7 +305,7 @@ snapshots[
     "TestJobService.test_create_multicam[-None-expand_rig] create_mutation_expand_rig"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -308,6 +314,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -325,6 +332,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -369,7 +377,7 @@ snapshots[
     "TestJobService.test_create_multicam[-None-expand_take] create_mutation_expand_take"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -378,6 +386,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -398,6 +407,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 849,
@@ -461,7 +471,7 @@ snapshots[
     "TestJobService.test_create_multicam[-None-no_expand] create_mutation_expand_None"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -470,6 +480,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -483,6 +494,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -525,7 +537,7 @@ snapshots[
     "TestJobService.test_create_multicam[-options1-empty_expand] create_mutation_expand_[]"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -534,6 +546,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -547,6 +560,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -592,7 +606,7 @@ snapshots[
     "TestJobService.test_create_multicam[-options1-expand_client] create_mutation_expand_client"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -601,6 +615,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -622,6 +637,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -679,7 +695,7 @@ snapshots[
     "TestJobService.test_create_multicam[-options1-expand_outputs] create_mutation_expand_outputs"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -688,6 +704,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -715,6 +732,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -823,7 +841,7 @@ snapshots[
     "TestJobService.test_create_multicam[-options1-expand_rig] create_mutation_expand_rig"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -832,6 +850,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -849,6 +868,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -896,7 +916,7 @@ snapshots[
     "TestJobService.test_create_multicam[-options1-expand_take] create_mutation_expand_take"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -905,6 +925,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -925,6 +946,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 849,
@@ -991,7 +1013,7 @@ snapshots[
     "TestJobService.test_create_multicam[-options1-no_expand] create_mutation_expand_None"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -1000,6 +1022,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -1013,6 +1036,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -1058,7 +1082,7 @@ snapshots[
     "TestJobService.test_create_multicam[move_mo-None-empty_expand] create_mutation_expand_[]"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -1067,6 +1091,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -1080,6 +1105,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -1122,7 +1148,7 @@ snapshots[
     "TestJobService.test_create_multicam[move_mo-None-expand_client] create_mutation_expand_client"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -1131,6 +1157,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -1152,6 +1179,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -1206,7 +1234,7 @@ snapshots[
     "TestJobService.test_create_multicam[move_mo-None-expand_outputs] create_mutation_expand_outputs"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -1215,6 +1243,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -1242,6 +1271,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -1347,7 +1377,7 @@ snapshots[
     "TestJobService.test_create_multicam[move_mo-None-expand_rig] create_mutation_expand_rig"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -1356,6 +1386,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -1373,6 +1404,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -1417,7 +1449,7 @@ snapshots[
     "TestJobService.test_create_multicam[move_mo-None-expand_take] create_mutation_expand_take"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -1426,6 +1458,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -1446,6 +1479,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 849,
@@ -1509,7 +1543,7 @@ snapshots[
     "TestJobService.test_create_multicam[move_mo-None-no_expand] create_mutation_expand_None"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -1518,6 +1552,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -1531,6 +1566,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -1573,7 +1609,7 @@ snapshots[
     "TestJobService.test_create_multicam[move_mo-options1-empty_expand] create_mutation_expand_[]"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -1582,6 +1618,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -1595,6 +1632,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -1640,7 +1678,7 @@ snapshots[
     "TestJobService.test_create_multicam[move_mo-options1-expand_client] create_mutation_expand_client"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -1649,6 +1687,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -1670,6 +1709,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -1727,7 +1767,7 @@ snapshots[
     "TestJobService.test_create_multicam[move_mo-options1-expand_outputs] create_mutation_expand_outputs"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -1736,6 +1776,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -1763,6 +1804,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -1871,7 +1913,7 @@ snapshots[
     "TestJobService.test_create_multicam[move_mo-options1-expand_rig] create_mutation_expand_rig"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -1880,6 +1922,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -1897,6 +1940,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -1944,7 +1988,7 @@ snapshots[
     "TestJobService.test_create_multicam[move_mo-options1-expand_take] create_mutation_expand_take"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -1953,6 +1997,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -1973,6 +2018,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 849,
@@ -2039,7 +2085,7 @@ snapshots[
     "TestJobService.test_create_multicam[move_mo-options1-no_expand] create_mutation_expand_None"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -2048,6 +2094,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -2061,6 +2108,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "numberOfActors": 8658,
@@ -2106,13 +2154,14 @@ snapshots[
     "TestJobService.test_create_singlecam[no_options-empty_expand] create_mutation_expand_[]"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON) {
+        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $clip_window: ClipWindowInput) {
   createSingleCamJob(
     takeId: $take_id
     name: $name
     options: $options
     outputs: $outputs
     metadata: $metadata
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -2126,6 +2175,10 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": {
+                "endTime": 10.0,
+                "startTime": 1.0,
+            },
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "options": {},
@@ -2166,13 +2219,14 @@ snapshots[
     "TestJobService.test_create_singlecam[no_options-expand_client] create_mutation_expand_client"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON) {
+        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $clip_window: ClipWindowInput) {
   createSingleCamJob(
     takeId: $take_id
     name: $name
     options: $options
     outputs: $outputs
     metadata: $metadata
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -2194,6 +2248,10 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": {
+                "endTime": 10.0,
+                "startTime": 1.0,
+            },
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "options": {},
@@ -2246,13 +2304,14 @@ snapshots[
     "TestJobService.test_create_singlecam[no_options-expand_outputs] create_mutation_expand_outputs"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON) {
+        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $clip_window: ClipWindowInput) {
   createSingleCamJob(
     takeId: $take_id
     name: $name
     options: $options
     outputs: $outputs
     metadata: $metadata
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -2280,6 +2339,10 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": {
+                "endTime": 10.0,
+                "startTime": 1.0,
+            },
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "options": {},
@@ -2383,13 +2446,14 @@ snapshots[
     "TestJobService.test_create_singlecam[no_options-expand_take] create_mutation_expand_take"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON) {
+        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $clip_window: ClipWindowInput) {
   createSingleCamJob(
     takeId: $take_id
     name: $name
     options: $options
     outputs: $outputs
     metadata: $metadata
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -2410,6 +2474,10 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": {
+                "endTime": 10.0,
+                "startTime": 1.0,
+            },
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "options": {},
@@ -2471,13 +2539,14 @@ snapshots[
     "TestJobService.test_create_singlecam[no_options-no_expand] create_mutation_expand_None"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON) {
+        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $clip_window: ClipWindowInput) {
   createSingleCamJob(
     takeId: $take_id
     name: $name
     options: $options
     outputs: $outputs
     metadata: $metadata
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -2491,6 +2560,10 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": {
+                "endTime": 10.0,
+                "startTime": 1.0,
+            },
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "options": {},
@@ -2531,13 +2604,14 @@ snapshots[
     "TestJobService.test_create_singlecam[with_options-empty_expand] create_mutation_expand_[]"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON) {
+        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $clip_window: ClipWindowInput) {
   createSingleCamJob(
     takeId: $take_id
     name: $name
     options: $options
     outputs: $outputs
     metadata: $metadata
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -2551,6 +2625,10 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": {
+                "endTime": 10.0,
+                "startTime": 1.0,
+            },
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "options": {
@@ -2594,13 +2672,14 @@ snapshots[
     "TestJobService.test_create_singlecam[with_options-expand_client] create_mutation_expand_client"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON) {
+        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $clip_window: ClipWindowInput) {
   createSingleCamJob(
     takeId: $take_id
     name: $name
     options: $options
     outputs: $outputs
     metadata: $metadata
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -2622,6 +2701,10 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": {
+                "endTime": 10.0,
+                "startTime": 1.0,
+            },
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "options": {
@@ -2677,13 +2760,14 @@ snapshots[
     "TestJobService.test_create_singlecam[with_options-expand_outputs] create_mutation_expand_outputs"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON) {
+        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $clip_window: ClipWindowInput) {
   createSingleCamJob(
     takeId: $take_id
     name: $name
     options: $options
     outputs: $outputs
     metadata: $metadata
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -2711,6 +2795,10 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": {
+                "endTime": 10.0,
+                "startTime": 1.0,
+            },
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "options": {
@@ -2817,13 +2905,14 @@ snapshots[
     "TestJobService.test_create_singlecam[with_options-expand_take] create_mutation_expand_take"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON) {
+        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $clip_window: ClipWindowInput) {
   createSingleCamJob(
     takeId: $take_id
     name: $name
     options: $options
     outputs: $outputs
     metadata: $metadata
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -2844,6 +2933,10 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": {
+                "endTime": 10.0,
+                "startTime": 1.0,
+            },
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "options": {
@@ -2908,13 +3001,14 @@ snapshots[
     "TestJobService.test_create_singlecam[with_options-no_expand] create_mutation_expand_None"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON) {
+        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $clip_window: ClipWindowInput) {
   createSingleCamJob(
     takeId: $take_id
     name: $name
     options: $options
     outputs: $outputs
     metadata: $metadata
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -2928,6 +3022,10 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": {
+                "endTime": 10.0,
+                "startTime": 1.0,
+            },
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "",
             "options": {
@@ -3159,7 +3257,7 @@ snapshots[
     "TestJobService.test_output_types[None-create_multicam] create_multicam_response"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -3168,6 +3266,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -3181,6 +3280,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": "{}",
             "name": "",
             "numberOfActors": 8658,
@@ -3196,13 +3296,14 @@ snapshots[
     "TestJobService.test_output_types[None-create_singlecam] create_singlecam_response"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON) {
+        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $clip_window: ClipWindowInput) {
   createSingleCamJob(
     takeId: $take_id
     name: $name
     options: $options
     outputs: $outputs
     metadata: $metadata
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -3216,6 +3317,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": "{}",
             "name": "",
             "options": {},
@@ -3229,7 +3331,7 @@ snapshots[
     "TestJobService.test_output_types[outputs1-create_multicam] create_multicam_response"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -3238,6 +3340,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -3251,6 +3354,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": "{}",
             "name": "",
             "numberOfActors": 8658,
@@ -3266,13 +3370,14 @@ snapshots[
     "TestJobService.test_output_types[outputs1-create_singlecam] create_singlecam_response"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON) {
+        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $clip_window: ClipWindowInput) {
   createSingleCamJob(
     takeId: $take_id
     name: $name
     options: $options
     outputs: $outputs
     metadata: $metadata
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -3286,6 +3391,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": "{}",
             "name": "",
             "options": {},
@@ -3299,7 +3405,7 @@ snapshots[
     "TestJobService.test_output_types[outputs2-create_multicam] create_multicam_response"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -3308,6 +3414,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -3321,6 +3428,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": "{}",
             "name": "",
             "numberOfActors": 8658,
@@ -3339,13 +3447,14 @@ snapshots[
     "TestJobService.test_output_types[outputs2-create_singlecam] create_singlecam_response"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON) {
+        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $clip_window: ClipWindowInput) {
   createSingleCamJob(
     takeId: $take_id
     name: $name
     options: $options
     outputs: $outputs
     metadata: $metadata
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -3359,6 +3468,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": "{}",
             "name": "",
             "options": {},
@@ -3375,7 +3485,7 @@ snapshots[
     "TestJobService.test_output_types[outputs3-create_multicam] create_multicam_response"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String) {
+        """mutation create($take_id: String!, $name: String, $numberOfActors: Int!, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $rig: String, $clip_window: ClipWindowInput) {
   createMultiCamJob(
     takeId: $take_id
     name: $name
@@ -3384,6 +3494,7 @@ snapshots[
     outputs: $outputs
     metadata: $metadata
     rig: $rig
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -3397,6 +3508,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": "{}",
             "name": "",
             "numberOfActors": 8658,
@@ -3415,13 +3527,14 @@ snapshots[
     "TestJobService.test_output_types[outputs3-create_singlecam] create_singlecam_response"
 ] = [
     [
-        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON) {
+        """mutation create($take_id: String!, $name: String, $options: OptionsInput, $outputs: [OutputType], $metadata: AWSJSON, $clip_window: ClipWindowInput) {
   createSingleCamJob(
     takeId: $take_id
     name: $name
     options: $options
     outputs: $outputs
     metadata: $metadata
+    clipWindow: $clip_window
   ) {
     id
     created
@@ -3435,6 +3548,7 @@ snapshots[
     {
         "operation_name": None,
         "variable_values": {
+            "clip_window": None,
             "metadata": "{}",
             "name": "",
             "options": {},

--- a/tests/services/snapshots/snap_test_take.py
+++ b/tests/services/snapshots/snap_test_take.py
@@ -135,7 +135,6 @@ snapshots[
     "sources": [
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -168,7 +167,6 @@ snapshots[
         },
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -356,7 +354,6 @@ snapshots[
     "sources": [
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -537,7 +534,6 @@ snapshots[
                     "cameraSettings": {
                         "lens": "area",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "white",
                     "fileId": "a8491a43-874a-40b9-8d86-63243ab5ed05",
                     "format": "MP4",
@@ -546,7 +542,6 @@ snapshots[
                     "cameraSettings": {
                         "lens": "director",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "white",
                     "fileId": "bdc68ffa-06c7-44f6-b4c4-614f530e9daa",
                     "format": "MOVE",
@@ -618,10 +613,6 @@ snapshots[
       cameraSettings {
         lens
       }
-      clipWindow {
-        startTime
-        endTime
-      }
     }
     __typename
   }
@@ -637,7 +628,6 @@ snapshots[
                     "cameraSettings": {
                         "lens": "area",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "white",
                     "fileId": "a8491a43-874a-40b9-8d86-63243ab5ed05",
                     "format": "MP4",
@@ -646,7 +636,6 @@ snapshots[
                     "cameraSettings": {
                         "lens": "director",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "white",
                     "fileId": "bdc68ffa-06c7-44f6-b4c4-614f530e9daa",
                     "format": "MOVE",
@@ -685,7 +674,6 @@ snapshots[
     "sources": [
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -712,7 +700,6 @@ snapshots[
         },
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -779,7 +766,6 @@ snapshots[
                     "cameraSettings": {
                         "lens": "area",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "white",
                     "fileId": "a8491a43-874a-40b9-8d86-63243ab5ed05",
                     "format": "MP4",
@@ -788,7 +774,6 @@ snapshots[
                     "cameraSettings": {
                         "lens": "director",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "white",
                     "fileId": "bdc68ffa-06c7-44f6-b4c4-614f530e9daa",
                     "format": "MOVE",
@@ -868,10 +853,6 @@ snapshots[
       cameraSettings {
         lens
       }
-      clipWindow {
-        startTime
-        endTime
-      }
     }
     __typename
   }
@@ -887,7 +868,6 @@ snapshots[
                     "cameraSettings": {
                         "lens": "area",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "white",
                     "fileId": "a8491a43-874a-40b9-8d86-63243ab5ed05",
                     "format": "MP4",
@@ -896,7 +876,6 @@ snapshots[
                     "cameraSettings": {
                         "lens": "director",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "white",
                     "fileId": "bdc68ffa-06c7-44f6-b4c4-614f530e9daa",
                     "format": "MOVE",
@@ -935,7 +914,6 @@ snapshots[
     "sources": [
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -1010,7 +988,6 @@ fragment HumanVolumeFragment on HumanVolume {
                     "cameraSettings": {
                         "lens": "area",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "white",
                     "fileId": "a8491a43-874a-40b9-8d86-63243ab5ed05",
                     "format": "MP4",
@@ -1019,7 +996,6 @@ fragment HumanVolumeFragment on HumanVolume {
                     "cameraSettings": {
                         "lens": "director",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "white",
                     "fileId": "bdc68ffa-06c7-44f6-b4c4-614f530e9daa",
                     "format": "MOVE",
@@ -1111,7 +1087,6 @@ snapshots[
                     "cameraSettings": {
                         "lens": "area",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "white",
                     "fileId": "a8491a43-874a-40b9-8d86-63243ab5ed05",
                     "format": "MP4",
@@ -1120,7 +1095,6 @@ snapshots[
                     "cameraSettings": {
                         "lens": "director",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "white",
                     "fileId": "bdc68ffa-06c7-44f6-b4c4-614f530e9daa",
                     "format": "MOVE",
@@ -1337,7 +1311,6 @@ snapshots[
     "sources": [
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -1370,7 +1343,6 @@ snapshots[
         },
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -1532,7 +1504,6 @@ snapshots[
     "sources": [
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -1736,7 +1707,6 @@ snapshots[
     "sources": [
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -1769,7 +1739,6 @@ snapshots[
         },
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -1935,7 +1904,6 @@ snapshots[
     "sources": [
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,

--- a/tests/services/snapshots/snap_test_volume.py
+++ b/tests/services/snapshots/snap_test_volume.py
@@ -8,7 +8,7 @@ snapshots = Snapshot()
 
 snapshots["TestVolumeService.test_create[empty_expand] create_mutation_expand_[]"] = [
     [
-        """mutation create($sources: [SourceInput!], $syncMethod: SyncMethodInput, $areaType: AreaType!, $humanHeight: Float!, $metadata: AWSJSON, $name: String) {
+        """mutation create($sources: [SourceInput!], $syncMethod: SyncMethodInput, $areaType: AreaType!, $humanHeight: Float!, $metadata: AWSJSON, $name: String, $clip_window: ClipWindowInput) {
   createVolumeWithHuman(
     sources: $sources
     syncMethod: $syncMethod
@@ -16,6 +16,7 @@ snapshots["TestVolumeService.test_create[empty_expand] create_mutation_expand_[]
     humanHeight: $humanHeight
     metadata: $metadata
     name: $name
+    clipWindow: $clip_window
   ) {
     id
     areaType
@@ -32,6 +33,10 @@ snapshots["TestVolumeService.test_create[empty_expand] create_mutation_expand_[]
         "operation_name": None,
         "variable_values": {
             "areaType": "NORMAL",
+            "clip_window": {
+                "endTime": 9057.0,
+                "startTime": 3757.0,
+            },
             "humanHeight": 873121848153.264,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "attention",
@@ -40,19 +45,14 @@ snapshots["TestVolumeService.test_create[empty_expand] create_mutation_expand_[]
                     "cameraSettings": {
                         "lens": "design",
                     },
-                    "clipWindow": {
-                        "endTime": 5315.0,
-                        "startTime": 849.0,
-                    },
                     "deviceLabel": "realize",
-                    "fileId": "874a50b9-8d86-4324-bab5-ed05e9c5e560",
+                    "fileId": "530e9daa-0d45-45a7-a849-1a43874a50b9",
                     "format": "MP4",
                 },
                 {
                     "cameraSettings": {
                         "lens": "so",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "realize",
                     "fileId": "b898a7a5-37be-4600-bdc6-8ffa06c7a4f6",
                     "format": "MOVE",
@@ -91,7 +91,7 @@ snapshots[
     "TestVolumeService.test_create[expand_additional_sources] create_mutation_expand_sources"
 ] = [
     [
-        """mutation create($sources: [SourceInput!], $syncMethod: SyncMethodInput, $areaType: AreaType!, $humanHeight: Float!, $metadata: AWSJSON, $name: String) {
+        """mutation create($sources: [SourceInput!], $syncMethod: SyncMethodInput, $areaType: AreaType!, $humanHeight: Float!, $metadata: AWSJSON, $name: String, $clip_window: ClipWindowInput) {
   createVolumeWithHuman(
     sources: $sources
     syncMethod: $syncMethod
@@ -99,6 +99,7 @@ snapshots[
     humanHeight: $humanHeight
     metadata: $metadata
     name: $name
+    clipWindow: $clip_window
   ) {
     id
     areaType
@@ -132,6 +133,10 @@ snapshots[
         "operation_name": None,
         "variable_values": {
             "areaType": "NORMAL",
+            "clip_window": {
+                "endTime": 9057.0,
+                "startTime": 3757.0,
+            },
             "humanHeight": 873121848153.264,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "attention",
@@ -140,19 +145,14 @@ snapshots[
                     "cameraSettings": {
                         "lens": "design",
                     },
-                    "clipWindow": {
-                        "endTime": 5315.0,
-                        "startTime": 849.0,
-                    },
                     "deviceLabel": "realize",
-                    "fileId": "874a50b9-8d86-4324-bab5-ed05e9c5e560",
+                    "fileId": "530e9daa-0d45-45a7-a849-1a43874a50b9",
                     "format": "MP4",
                 },
                 {
                     "cameraSettings": {
                         "lens": "so",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "realize",
                     "fileId": "b898a7a5-37be-4600-bdc6-8ffa06c7a4f6",
                     "format": "MOVE",
@@ -188,7 +188,6 @@ snapshots[
     "sources": [
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -215,7 +214,6 @@ snapshots[
         },
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -248,7 +246,7 @@ snapshots[
     "TestVolumeService.test_create[expand_client] create_mutation_expand_client"
 ] = [
     [
-        """mutation create($sources: [SourceInput!], $syncMethod: SyncMethodInput, $areaType: AreaType!, $humanHeight: Float!, $metadata: AWSJSON, $name: String) {
+        """mutation create($sources: [SourceInput!], $syncMethod: SyncMethodInput, $areaType: AreaType!, $humanHeight: Float!, $metadata: AWSJSON, $name: String, $clip_window: ClipWindowInput) {
   createVolumeWithHuman(
     sources: $sources
     syncMethod: $syncMethod
@@ -256,6 +254,7 @@ snapshots[
     humanHeight: $humanHeight
     metadata: $metadata
     name: $name
+    clipWindow: $clip_window
   ) {
     id
     areaType
@@ -280,6 +279,10 @@ snapshots[
         "operation_name": None,
         "variable_values": {
             "areaType": "NORMAL",
+            "clip_window": {
+                "endTime": 9057.0,
+                "startTime": 3757.0,
+            },
             "humanHeight": 873121848153.264,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "attention",
@@ -288,19 +291,14 @@ snapshots[
                     "cameraSettings": {
                         "lens": "design",
                     },
-                    "clipWindow": {
-                        "endTime": 5315.0,
-                        "startTime": 849.0,
-                    },
                     "deviceLabel": "realize",
-                    "fileId": "874a50b9-8d86-4324-bab5-ed05e9c5e560",
+                    "fileId": "530e9daa-0d45-45a7-a849-1a43874a50b9",
                     "format": "MP4",
                 },
                 {
                     "cameraSettings": {
                         "lens": "so",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "realize",
                     "fileId": "b898a7a5-37be-4600-bdc6-8ffa06c7a4f6",
                     "format": "MOVE",
@@ -349,7 +347,7 @@ snapshots[
     "TestVolumeService.test_create[expand_video_file] create_mutation_expand_sources"
 ] = [
     [
-        """mutation create($sources: [SourceInput!], $syncMethod: SyncMethodInput, $areaType: AreaType!, $humanHeight: Float!, $metadata: AWSJSON, $name: String) {
+        """mutation create($sources: [SourceInput!], $syncMethod: SyncMethodInput, $areaType: AreaType!, $humanHeight: Float!, $metadata: AWSJSON, $name: String, $clip_window: ClipWindowInput) {
   createVolumeWithHuman(
     sources: $sources
     syncMethod: $syncMethod
@@ -357,6 +355,7 @@ snapshots[
     humanHeight: $humanHeight
     metadata: $metadata
     name: $name
+    clipWindow: $clip_window
   ) {
     id
     areaType
@@ -390,6 +389,10 @@ snapshots[
         "operation_name": None,
         "variable_values": {
             "areaType": "NORMAL",
+            "clip_window": {
+                "endTime": 9057.0,
+                "startTime": 3757.0,
+            },
             "humanHeight": 873121848153.264,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "attention",
@@ -398,19 +401,14 @@ snapshots[
                     "cameraSettings": {
                         "lens": "design",
                     },
-                    "clipWindow": {
-                        "endTime": 5315.0,
-                        "startTime": 849.0,
-                    },
                     "deviceLabel": "realize",
-                    "fileId": "874a50b9-8d86-4324-bab5-ed05e9c5e560",
+                    "fileId": "530e9daa-0d45-45a7-a849-1a43874a50b9",
                     "format": "MP4",
                 },
                 {
                     "cameraSettings": {
                         "lens": "so",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "realize",
                     "fileId": "b898a7a5-37be-4600-bdc6-8ffa06c7a4f6",
                     "format": "MOVE",
@@ -446,7 +444,6 @@ snapshots[
     "sources": [
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -477,7 +474,7 @@ snapshots[
 
 snapshots["TestVolumeService.test_create[no_expand] create_mutation_expand_None"] = [
     [
-        """mutation create($sources: [SourceInput!], $syncMethod: SyncMethodInput, $areaType: AreaType!, $humanHeight: Float!, $metadata: AWSJSON, $name: String) {
+        """mutation create($sources: [SourceInput!], $syncMethod: SyncMethodInput, $areaType: AreaType!, $humanHeight: Float!, $metadata: AWSJSON, $name: String, $clip_window: ClipWindowInput) {
   createVolumeWithHuman(
     sources: $sources
     syncMethod: $syncMethod
@@ -485,6 +482,7 @@ snapshots["TestVolumeService.test_create[no_expand] create_mutation_expand_None"
     humanHeight: $humanHeight
     metadata: $metadata
     name: $name
+    clipWindow: $clip_window
   ) {
     id
     areaType
@@ -501,6 +499,10 @@ snapshots["TestVolumeService.test_create[no_expand] create_mutation_expand_None"
         "operation_name": None,
         "variable_values": {
             "areaType": "NORMAL",
+            "clip_window": {
+                "endTime": 9057.0,
+                "startTime": 3757.0,
+            },
             "humanHeight": 873121848153.264,
             "metadata": '{"decade": "zAvJMvacZIYSmMsDUNvC", "other": "XbBPNrbhtJksbBuoWXSK", "draw": "PnbQcVNCliYtuFCSJkGb", "table": "ACMVZcKAiGBcYgCzHAad", "huge": "eFaLyHGEQQpSzpRFSYEm", "last": "dnZCcfgZNBnaEkbOzIyO", "trouble": "UgnhIyaDJzohUigyDYZf", "analysis": "UmKdTFlLMIuIvJkRJnoM", "house": "aYyOUXkJPUjPJGpDdakX", "director": "KNmpExWtgQLcAEuRyBkN"}',
             "name": "attention",
@@ -509,19 +511,14 @@ snapshots["TestVolumeService.test_create[no_expand] create_mutation_expand_None"
                     "cameraSettings": {
                         "lens": "design",
                     },
-                    "clipWindow": {
-                        "endTime": 5315.0,
-                        "startTime": 849.0,
-                    },
                     "deviceLabel": "realize",
-                    "fileId": "874a50b9-8d86-4324-bab5-ed05e9c5e560",
+                    "fileId": "530e9daa-0d45-45a7-a849-1a43874a50b9",
                     "format": "MP4",
                 },
                 {
                     "cameraSettings": {
                         "lens": "so",
                     },
-                    "clipWindow": None,
                     "deviceLabel": "realize",
                     "fileId": "b898a7a5-37be-4600-bdc6-8ffa06c7a4f6",
                     "format": "MOVE",
@@ -767,7 +764,6 @@ snapshots[
     "sources": [
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -794,7 +790,6 @@ snapshots[
         },
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,
@@ -1089,7 +1084,6 @@ snapshots[
     "sources": [
         {
             "camera_settings": None,
-            "clip_window": None,
             "device_label": "foobar",
             "file": {
                 "client": None,

--- a/tests/services/test_job.py
+++ b/tests/services/test_job.py
@@ -5,7 +5,7 @@ from gql.transport.exceptions import TransportQueryError
 from graphql.execution.execute import ExecutionResult
 from pydantic import ValidationError
 
-from move_ugc.schemas.job import JobOptions
+from move_ugc.schemas.job import ClipWindow, JobOptions
 from tests.constants import LIST_JOBS_QUERY
 from tests.services.testcases import ServicesTestCase
 
@@ -66,6 +66,10 @@ class TestJobService(ServicesTestCase):  # noqa: WPS214
             metadata=request.getfixturevalue("metadata_for_update"),
             options=options,
             expand=expand,
+            clip_window=ClipWindow(
+                start_time=1.0,
+                end_time=10.0,  # noqa:WPS432
+            ),
         )
         suffix = "_".join(expand) if expand else str(expand)
         self.assert_execute(

--- a/tests/services/test_volume.py
+++ b/tests/services/test_volume.py
@@ -5,7 +5,8 @@ from graphql import ExecutionResult
 from pydantic import ValidationError
 
 from move_ugc.schemas.constants import OUTPUTS_LITERAL
-from move_ugc.schemas.sources import ClipWindow, SourceIn, TakeSourceKey
+from move_ugc.schemas.job import ClipWindow
+from move_ugc.schemas.sources import SourceIn, TakeSourceKey
 from move_ugc.schemas.volume import AreaType
 from tests.constants import LIST_VOLUMES_QUERY
 from tests.services.testcases import ServicesTestCase
@@ -58,15 +59,15 @@ class TestVolumeService(ServicesTestCase):
         device_label = faker.word()
         volume = self.client.volumes.create_human_volume(
             metadata=request.getfixturevalue("metadata_for_update"),
+            clip_window=ClipWindow(
+                start_time=faker.pyint(),
+                end_time=faker.pyint(),
+            ),
             sources=[
                 SourceIn(
                     device_label=device_label,
                     file_id=faker.uuid4(),
                     format=TakeSourceKey.mp4,
-                    clip_window=ClipWindow(
-                        start_time=faker.pyint(),
-                        end_time=faker.pyint(),
-                    ),
                     camera_settings={
                         "lens": faker.word(),
                     },


### PR DESCRIPTION
Clip window is no longer a valid input for sources. Instead it can now (optionally) be provided to a singlecam/multicam job, or for volume creation. If not provided the entire video is processed.
