### PR TITLE
fix: IST-2686: Update docs

### DIFF
--- a/docs/getting-started/usage/job.md
+++ b/docs/getting-started/usage/job.md
@@ -99,7 +99,7 @@ To create a multicam job, you can use the `create_multicam` method:
 ```python
 job = ugc.jobs.create_multicam(
     take_id="take-2be2463e-ffa3-419b-beb4-ea0f99c79512",
-    options=JobOptions(track_fingers=True),
+    options=JobOptions(trackFingers=True),
     name="My multicam job",
 )
 ```
@@ -107,3 +107,32 @@ job = ugc.jobs.create_multicam(
 See the [API reference](/move-ugc-python/latest/api-reference/services/job/#move_ugc.schemas.job.JobOptions) for more information on available job options for multicam.
 
 See quickstart guide [here](https://move-ai.github.io/move-ugc-api/getting-started/multicam/quickstart/) for steps to create a multicam job. Please use the equivalent methods in the SDK to create a multicam job.
+
+
+## Specifying options on a job
+
+You can configure how your job is processed by specifying a `JobOptions` argument to `job.create_singlecam`
+or `job.create_multicam`. The allowed options are being added to constantly. Please refer
+to the API docs [here](https://move-ai.github.io/move-ugc-api/schema/#optionsinput) for a full list
+of available options. Options should be specified exactly as  they are defined in the [API docs](https://move-ai.github.io/move-ugc-api/schema/#optionsinput)
+
+See examples below
+
+```python
+from move_ugc.schemas.job import JobOptions
+
+# Specifying options on a singlecam job
+job = ugc.jobs.create_singlecam(
+    take_id="take-2be2463e-ffa3-419b-beb4-ea0f99c79512",
+    options=JobOptions(trackFingers=True, floorPlane=True, mocapModel="S1"),
+)
+
+# Specifying options on a multicam job
+job = ugc.jobs.create_multicam(
+    take_id="take-2be2463e-ffa3-419b-beb4-ea0f99c79512",
+    options=JobOptions(trackFingers=True, floorPlane=True),
+)
+
+
+
+```

--- a/tests/services/snapshots/snap_test_job.py
+++ b/tests/services/snapshots/snap_test_job.py
@@ -565,7 +565,7 @@ snapshots[
             "name": "",
             "numberOfActors": 8658,
             "options": {
-                "floor_plane": True,
+                "floorPlane": True,
                 "trackFingers": False,
             },
             "outputs": [],
@@ -642,7 +642,7 @@ snapshots[
             "name": "",
             "numberOfActors": 8658,
             "options": {
-                "floor_plane": True,
+                "floorPlane": True,
                 "trackFingers": False,
             },
             "outputs": [],
@@ -737,7 +737,7 @@ snapshots[
             "name": "",
             "numberOfActors": 8658,
             "options": {
-                "floor_plane": True,
+                "floorPlane": True,
                 "trackFingers": False,
             },
             "outputs": [],
@@ -873,7 +873,7 @@ snapshots[
             "name": "",
             "numberOfActors": 8658,
             "options": {
-                "floor_plane": True,
+                "floorPlane": True,
                 "trackFingers": False,
             },
             "outputs": [],
@@ -951,7 +951,7 @@ snapshots[
             "name": "",
             "numberOfActors": 849,
             "options": {
-                "floor_plane": True,
+                "floorPlane": True,
                 "trackFingers": False,
             },
             "outputs": [],
@@ -1041,7 +1041,7 @@ snapshots[
             "name": "",
             "numberOfActors": 8658,
             "options": {
-                "floor_plane": True,
+                "floorPlane": True,
                 "trackFingers": False,
             },
             "outputs": [],
@@ -1637,7 +1637,7 @@ snapshots[
             "name": "",
             "numberOfActors": 8658,
             "options": {
-                "floor_plane": True,
+                "floorPlane": True,
                 "trackFingers": False,
             },
             "outputs": [],
@@ -1714,7 +1714,7 @@ snapshots[
             "name": "",
             "numberOfActors": 8658,
             "options": {
-                "floor_plane": True,
+                "floorPlane": True,
                 "trackFingers": False,
             },
             "outputs": [],
@@ -1809,7 +1809,7 @@ snapshots[
             "name": "",
             "numberOfActors": 8658,
             "options": {
-                "floor_plane": True,
+                "floorPlane": True,
                 "trackFingers": False,
             },
             "outputs": [],
@@ -1945,7 +1945,7 @@ snapshots[
             "name": "",
             "numberOfActors": 8658,
             "options": {
-                "floor_plane": True,
+                "floorPlane": True,
                 "trackFingers": False,
             },
             "outputs": [],
@@ -2023,7 +2023,7 @@ snapshots[
             "name": "",
             "numberOfActors": 849,
             "options": {
-                "floor_plane": True,
+                "floorPlane": True,
                 "trackFingers": False,
             },
             "outputs": [],
@@ -2113,7 +2113,7 @@ snapshots[
             "name": "",
             "numberOfActors": 8658,
             "options": {
-                "floor_plane": True,
+                "floorPlane": True,
                 "trackFingers": False,
             },
             "outputs": [],

--- a/tests/services/test_job.py
+++ b/tests/services/test_job.py
@@ -102,7 +102,7 @@ class TestJobService(ServicesTestCase):  # noqa: WPS214
     )
     @pytest.mark.parametrize(
         argnames="options",
-        argvalues=[None, JobOptions(trackFingers=False, floor_plane=True)],
+        argvalues=[None, JobOptions(trackFingers=False, floorPlane=True)],
     )
     @pytest.mark.parametrize(
         argnames="rig",


### PR DESCRIPTION
mocapModel is automatically supported as jobOptions is fully flexible and accepts new options on the API automatically. Have just updated the docs to make it a little clearer what is allowed
